### PR TITLE
feat: add evidence-driven selection and Kaggle benchmark protocol

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -25,6 +25,8 @@ updates:
           - "scikit-learn"
           - "imbalanced-learn"
           - "xgboost"
+          - "lightgbm"
+          - "catboost"
           - "shap"
         update-types:
           - "minor"
@@ -72,6 +74,12 @@ updates:
         update-types:
           - "version-update:semver-major"
       - dependency-name: "xgboost"
+        update-types:
+          - "version-update:semver-major"
+      - dependency-name: "lightgbm"
+        update-types:
+          - "version-update:semver-major"
+      - dependency-name: "catboost"
         update-types:
           - "version-update:semver-major"
       - dependency-name: "shap"

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 # Custom
 fitted_models/
 mamut_report/
+.cache/
+benchmark_results/
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/README.md
+++ b/README.md
@@ -26,6 +26,15 @@ MAMUT is best used as a readable baseline and experiment report generator for be
 - Reproducible benchmark diagnostics via `scripts/benchmark_evidence.py`.
 - External Kaggle benchmark harness with immutable campaign records, explicit validation estimands, and submission controls.
 
+## Recorded Benchmark Evidence
+The current evidence benchmark deliberately exposes cases where a simple
+baseline challenges the validation-selected candidate. On Kaggle Spaceship
+Titanic, the best recorded MAMUT public submission scored `0.80617` using a
+CatBoost-focused, post-leaderboard development campaign. This is evidence of
+an improved auditable baseline, not a state-of-the-art or private-leaderboard
+claim. Protocol details and limitations are recorded in the
+[Kaggle benchmarks documentation](https://mamut.readthedocs.io/en/latest/kaggle_benchmarks.html).
+
 ## Installation
 Python 3.12 is the target runtime (see `.python-version`).
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ MAMUT is best used as a readable baseline and experiment report generator for be
 - Report generation via `evaluate()` with metrics, plots, and SHAP explanations.
 - Configurable artifacts: `fit()` keeps models in memory by default and saves fitted models only when `save_models=True`.
 - Reproducible benchmark diagnostics via `scripts/benchmark_evidence.py`.
-- External Kaggle benchmark harness with development/confirmation separation and explicit submission controls.
+- External Kaggle benchmark harness with immutable campaign records, explicit validation estimands, and submission controls.
 
 ## Installation
 Python 3.12 is the target runtime (see `.python-version`).
@@ -111,7 +111,7 @@ uv run pre-commit run --all-files
 uv run make -C docs html
 uv run sphinx-build -W --keep-going -b html docs/source docs/build/html-strict
 uv run python scripts/benchmark_evidence.py
-uv run python scripts/benchmark_kaggle.py spaceship-titanic --stage development --runs 1 --n-iterations 1
+uv run python scripts/benchmark_kaggle.py spaceship-titanic --campaign-id smoke --stage development --runs 1 --n-iterations 1
 uv build
 uv run twine check dist/*
 ```

--- a/README.md
+++ b/README.md
@@ -11,19 +11,20 @@
 ![License](https://img.shields.io/github/license/przybytniowskaj/Mamut)
 
 ## Overview
-MAMUT is a Python toolkit for transparent **classification** workflows on tabular data. It bundles preprocessing, Optuna-driven hyperparameter optimization, model comparison, validation diagnostics, and reporting into a single workflow built on scikit-learn and XGBoost.
+MAMUT is a Python toolkit for transparent **classification** workflows on tabular data. It bundles preprocessing, Optuna-driven hyperparameter optimization, model comparison, validation diagnostics, and reporting into a single workflow built on scikit-learn, XGBoost, LightGBM, and CatBoost.
 
 MAMUT is best used as a readable baseline and experiment report generator for beginners, small teams, and portfolio-scale projects. It is not positioned as a replacement for industrial AutoML systems such as AutoGluon, FLAML, or H2O AutoML; its value is in showing what was tried, how the result was validated, and whether simple baselines challenge the selected model.
 
 ## Key Features
-- End-to-end preprocessing: missing values, categorical encoding, skew correction, scaling, outlier filtering, imbalance handling (SMOTE/undersampling/SMOTETomek), optional feature selection, and PCA.
-- Model search across common classifiers (LogisticRegression, RandomForestClassifier, SVC, XGBClassifier, MLPClassifier, GaussianNB, KNeighborsClassifier).
+- End-to-end preprocessing: missing values, categorical encoding, skew correction, scaling, optional outlier filtering, imbalance handling (SMOTE/undersampling/SMOTETomek), optional feature selection, and PCA.
+- Model search across common and boosted classifiers, including LogisticRegression, RandomForestClassifier, ExtraTreesClassifier, HistGradientBoostingClassifier, XGBClassifier, LGBMClassifier, CatBoostClassifier, GaussianNB, SVC, MLPClassifier, and KNeighborsClassifier.
 - Hyperparameter optimization with Optuna (TPE/Bayesian or random search).
-- Validation-based model selection with optional final holdout evaluation.
-- Evidence reporting: leakage checks, dummy/logistic/random-forest baselines, repeated stratified CV, and approximate score intervals.
+- Validation-based model selection with optional nested CV, group-disjoint splits, and final holdout evaluation.
+- Evidence reporting: leakage checks, fitted-candidate comparison, dummy/logistic/random-forest baselines, and descriptive score-stability intervals from repeated stratified or grouped CV.
 - Report generation via `evaluate()` with metrics, plots, and SHAP explanations.
 - Configurable artifacts: `fit()` keeps models in memory by default and saves fitted models only when `save_models=True`.
 - Reproducible benchmark diagnostics via `scripts/benchmark_evidence.py`.
+- External Kaggle benchmark harness with development/confirmation separation and explicit submission controls.
 
 ## Installation
 Python 3.12 is the target runtime (see `.python-version`).
@@ -56,6 +57,7 @@ mamut = Mamut(
     n_iterations=1,
     optimization_method="random_search",
     holdout_size=0.2,
+    refit_final_model=True,
     random_state=42,
 )
 mamut.fit(X, y)
@@ -68,24 +70,32 @@ report = mamut.evaluate(include_shap=False, write_html=False, save_plots=False)
 ## Configuration Notes
 - With preprocessing enabled (default), pass `X` as a pandas `DataFrame` and `y` as a `Series`.
 - Targets must be categorical (float targets raise a `ValueError`).
-- `fit()` performs a stratified train/validation split controlled by `validation_size` and `random_state`.
+- `fit()` performs a stratified train/validation split controlled by `validation_size` and `random_state`; pass `groups=` to keep related rows in the same partition.
 - Set `holdout_size` or pass `X_holdout`/`y_holdout` to reserve final evaluation data that is not used for model or ensemble selection.
 - Select the optimization strategy with `optimization_method="bayes"` or `"random_search"`.
 - Control the search budget with `n_iterations`.
-- Exclude models by class name (e.g., `exclude_models=["SVC"]`).
-- Preprocessing options are passed directly into `Mamut(...)` (e.g., `pca=True`, `feature_selection=True`, `num_imputation="knn"`).
-- Unknown categorical levels at prediction time are ignored by the one-hot encoder instead of failing the prediction.
+- Choose a model pool with `search_profile="quick"`, `"balanced"`, or `"thorough"`.
+- Include exact models with `include_models=["RandomForestClassifier", "LGBMClassifier"]`, or exclude models by class name with `exclude_models=["SVC"]`.
+- Use `selection_strategy="nested_cv"` for fold-local tuning and model comparison when runtime matters less than selection confidence.
+- Control parallelism for supported estimators with `n_jobs`.
+- `preprocessing_profile="auto"` lets tree and native-boosting candidates use model-aware preprocessing; set `preprocessing_profile="generic_ohe"` to force the legacy shared one-hot path.
+- Preprocessing options are passed directly into `Mamut(...)` (e.g., `pca=True`, `feature_selection=True`, `num_imputation="knn"`). Native categorical preprocessing falls back to one-hot when PCA, feature selection, or imbalance resampling requires numeric arrays.
+- Automatic outlier row removal is disabled by default; enable it explicitly with `outlier_removal=True`.
+- Unknown categorical levels at prediction time are ignored by one-hot profiles instead of failing the prediction.
 - Set `verbose=True` to show model-search progress logging and Optuna progress bars.
 - Use `save_models=True` to write fitted candidate pipelines under `./fitted_models/<timestamp>/`.
 - Use `refit_final_model=True` only after you accept validation and holdout diagnostics; the final refit uses all non-holdout modeling data and never uses holdout rows.
 - `score_metric` expects one of: `accuracy`, `precision`, `recall`, `f1`, `balanced_accuracy`, `jaccard`, `roc_auc_score`.
-- Configure evidence stability checks with `evidence_cv_splits`, `evidence_cv_repeats`, and `evidence_confidence_level`.
+- Configure descriptive evidence stability checks with `evidence_cv_splits`, `evidence_cv_repeats`, and `evidence_confidence_level`; dependent CV fold intervals are not final confidence claims.
 
 ## Outputs and Reports
 - `mamut.best_model_`: validation-selected public prediction pipeline after `fit`; `predict()` returns original target labels.
 - `mamut.validation_summary_`: per-model validation scores and timings.
-- `mamut.holdout_summary_`: optional final holdout scores when holdout data is configured.
+- `mamut.selection_summary_`: model-selection diagnostics for the active selection strategy.
+- `mamut.fitted_preprocessors_`: fitted candidate-specific preprocessors keyed by model name.
+- `mamut.holdout_summary_`: optional final holdout diagnostic scores when holdout data is configured; use a refitted selected model for final deployment scoring.
 - `mamut.evidence_report_`: validation integrity, evidence-guided selection, leakage checks, baseline comparison, and score stability tables generated by `evaluate()` or `generate_evidence()`.
+- Use `generate_evidence(dataset="holdout", include_candidate_comparison=False)` for a locked final confirmation report that does not score alternate MAMUT candidates on the holdout.
 - `mamut.optuna_studies_`: Optuna studies keyed by model name.
 - `mamut.evaluate()`: writes an HTML report to `./mamut_report/report_<timestamp>.html` and stores plots in `./mamut_report/plots/`. It uses holdout data automatically when available and includes evidence sections by default.
 - `mamut.evaluate(include_shap=False, write_html=False, save_plots=False)`: run lightweight evaluation without expensive SHAP or file artifacts.
@@ -101,6 +111,7 @@ uv run pre-commit run --all-files
 uv run make -C docs html
 uv run sphinx-build -W --keep-going -b html docs/source docs/build/html-strict
 uv run python scripts/benchmark_evidence.py
+uv run python scripts/benchmark_kaggle.py spaceship-titanic --stage development --runs 1 --n-iterations 1
 uv build
 uv run twine check dist/*
 ```
@@ -111,6 +122,7 @@ uv run twine check dist/*
 - User guide: https://mamut.readthedocs.io/en/latest/user_guide.html
 - Reports and artifacts: https://mamut.readthedocs.io/en/latest/reports.html
 - Evidence benchmark: https://mamut.readthedocs.io/en/latest/benchmark_evidence.html
+- Kaggle benchmarks: https://mamut.readthedocs.io/en/latest/kaggle_benchmarks.html
 - API reference: https://mamut.readthedocs.io/en/latest/mamut.html
 - Notebook walkthrough: `docs/source/notebooks/walkthrough.ipynb`
 - Changelog: `CHANGELOG.md`

--- a/docs/source/benchmark_evidence.rst
+++ b/docs/source/benchmark_evidence.rst
@@ -39,9 +39,9 @@ a release validation pass:
 
    | dataset       | samples | features | classes | selected_model     | holdout_score | best_baseline       | best_baseline_score | repeated_cv_mean | repeated_cv_ci | guidance   | leakage_warnings |
    | ------------- | ------- | -------- | ------- | ------------------ | ------------- | ------------------- | ------------------- | ---------------- | -------------- | ---------- | ---------------- |
-   | breast_cancer | 569     | 30       | 2       | LogisticRegression     | 0.981         | Logistic Regression | 0.953               | 0.972            | [0.932, 1.000] | confirmed  | 0                |
+   | breast_cancer | 569     | 30       | 2       | RandomForestClassifier | 0.943         | Logistic Regression | 0.953               | 0.958            | [0.879, 1.000] | challenged | 0                |
    | digits        | 1797    | 64       | 10      | RandomForestClassifier | 0.969         | Random Forest       | 0.969               | 0.962            | [0.939, 0.986] | challenged | 0                |
-   | wine          | 178     | 13       | 3       | LogisticRegression     | 1.000         | Logistic Regression | 1.000               | 0.988            | [0.963, 1.000] | confirmed  | 0                |
+   | wine          | 178     | 13       | 3       | LogisticRegression     | 1.000         | Logistic Regression | 1.000               | 0.981            | [0.934, 1.000] | confirmed  | 0                |
 
 Interpretation
 --------------
@@ -52,8 +52,10 @@ selected model strongly enough to require review. A challenge is useful signal:
 it prevents MAMUT from presenting a validation-selected model as stronger than
 the evidence supports.
 
-On ``digits``, a random-forest candidate is selected and the evidence still
-marks the result for review rather than treating a single holdout result as
-conclusive. On ``wine``, the holdout score is saturated, while score-stability
-evidence remains visible. This is the intended behavior: small datasets with
-perfect holdout scores still need stability checks.
+On ``breast_cancer``, a simple logistic-regression baseline beats the selected
+random-forest candidate on the holdout split, and MAMUT surfaces that
+challenge. On ``digits``, a random-forest baseline matches the selected
+candidate closely enough to require review. On ``wine``, the holdout score is
+saturated while score-stability evidence remains visible. This is the intended
+behavior: attractive holdout results do not suppress baseline or stability
+checks.

--- a/docs/source/benchmark_evidence.rst
+++ b/docs/source/benchmark_evidence.rst
@@ -9,7 +9,7 @@ MAMUT includes a lightweight benchmark script for release diagnostics. The goal
 is not to claim state-of-the-art AutoML performance. The goal is to verify that
 the selected model beats trivial baselines, that stronger baselines are visible
 when they challenge the selection, and that score stability is reported with
-approximate score intervals.
+descriptive resampling intervals.
 
 Run the benchmark from the repository root:
 
@@ -23,9 +23,11 @@ The default run uses:
 * fixed ``random_state=42``
 * ``balanced_accuracy`` as the selection metric
 * ``holdout_size=0.2`` for final evaluation
+* final refit on all non-holdout modeling rows before holdout scoring
 * one random-search iteration for speed
 * three-fold repeated stratified CV with one repeat for score stability
-* a lightweight candidate set that excludes SVC, MLP, and XGBoost
+* the lightweight ``quick`` candidate profile (logistic regression, random
+  forest, extra trees, and Gaussian naive Bayes)
 
 Example Diagnostic Output
 -------------------------
@@ -37,9 +39,9 @@ a release validation pass:
 
    | dataset       | samples | features | classes | selected_model     | holdout_score | best_baseline       | best_baseline_score | repeated_cv_mean | repeated_cv_ci | guidance   | leakage_warnings |
    | ------------- | ------- | -------- | ------- | ------------------ | ------------- | ------------------- | ------------------- | ---------------- | -------------- | ---------- | ---------------- |
-   | breast_cancer | 569     | 30       | 2       | LogisticRegression | 0.960         | Logistic Regression | 0.948               | 0.968            | [0.928, 1.000] | confirmed  | 0                |
-   | digits        | 1797    | 64       | 10      | LogisticRegression | 0.949         | Random Forest       | 0.972               | 0.948            | [0.932, 0.965] | challenged | 0                |
-   | wine          | 178     | 13       | 3       | LogisticRegression | 1.000         | Logistic Regression | 1.000               | 0.964            | [0.886, 1.000] | challenged | 0                |
+   | breast_cancer | 569     | 30       | 2       | LogisticRegression     | 0.981         | Logistic Regression | 0.953               | 0.972            | [0.932, 1.000] | confirmed  | 0                |
+   | digits        | 1797    | 64       | 10      | RandomForestClassifier | 0.969         | Random Forest       | 0.969               | 0.962            | [0.939, 0.986] | challenged | 0                |
+   | wine          | 178     | 13       | 3       | LogisticRegression     | 1.000         | Logistic Regression | 1.000               | 0.988            | [0.963, 1.000] | confirmed  | 0                |
 
 Interpretation
 --------------
@@ -50,9 +52,8 @@ selected model strongly enough to require review. A challenge is useful signal:
 it prevents MAMUT from presenting a validation-selected model as stronger than
 the evidence supports.
 
-On ``digits``, Random Forest performs better on holdout than the selected
-Logistic Regression candidate. MAMUT reports this instead of silently changing
-the chosen model after looking at holdout data. On ``wine``, the holdout score
-is saturated, but repeated validation still challenges the selected candidate.
-That is the intended behavior: small datasets with perfect holdout scores still
-need stability checks.
+On ``digits``, a random-forest candidate is selected and the evidence still
+marks the result for review rather than treating a single holdout result as
+conclusive. On ``wine``, the holdout score is saturated, while score-stability
+evidence remains visible. This is the intended behavior: small datasets with
+perfect holdout scores still need stability checks.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -24,12 +24,15 @@ Highlights
 * Automated preprocessing for missing values, categorical variables, skewed
   numeric features, scaling, outliers, class imbalance, optional feature
   selection, and optional PCA.
-* Model search across common scikit-learn classifiers and XGBoost.
+* Model search across common scikit-learn classifiers, XGBoost, LightGBM, and
+  CatBoost.
 * Hyperparameter optimization with Optuna using Bayesian or random search.
 * Evaluation reports with metrics, confusion matrices, ROC curves, feature
   importances, and SHAP plots.
-* Evidence diagnostics with leakage checks, baseline comparison, score
-  stability, and approximate score intervals.
+* Evidence diagnostics with leakage checks, baseline comparison, and
+  descriptive score-stability intervals.
+* Group-aware splits and nested-CV selection for related observations such as
+  households, sessions, or passenger groups.
 * Configurable model artifacts for the best model and fitted candidate models.
 
 Start Here
@@ -59,6 +62,7 @@ Minimal Example
        n_iterations=1,
        optimization_method="random_search",
        holdout_size=0.2,
+       refit_final_model=True,
        random_state=42,
    )
    mamut.fit(X, y)
@@ -84,6 +88,7 @@ Documentation
    user_guide
    reports
    benchmark_evidence
+   kaggle_benchmarks
 
 .. toctree::
    :maxdepth: 2

--- a/docs/source/kaggle_benchmarks.rst
+++ b/docs/source/kaggle_benchmarks.rst
@@ -56,6 +56,7 @@ Development Run
      --selection-strategy single_split \
      --runs 5 \
      --n-iterations 3 \
+     --n-jobs -1 \
      --max-runtime-seconds 900 \
      --format markdown
 
@@ -64,7 +65,12 @@ under ``.cache/mamut/benchmark-results/<competition>/<campaign>/<recipe>/<run>/`
 The manifest records configuration, data hashes, source commit, branch,
 dirty-tree state, evaluation estimand, and train/test relational-overlap
 audit. ``--max-runtime-seconds`` is a soft budget checked between completed
-outer runs; a single model fit can exceed it.
+outer runs; a single model fit can exceed it. The harness prints and records
+an upper-bound estimate of tuned candidate fits. Use fixed-family
+``single_split`` screening for development before considering costly nested
+multi-family selection.
+Use ``--n-jobs -1`` for workstation screening when CPU resources are
+available; the value is included in the manifest for reproducibility.
 
 Locked Confirmation and Submission
 ----------------------------------
@@ -121,3 +127,9 @@ did not establish superior competitive performance. In paired post-score
 development evaluation, adding those batch aggregates improved LightGBM only
 slightly and did not improve CatBoost; model-family choice accounted for the
 substantial measured gain.
+
+A separate household-component-disjoint CatBoost development run at commit
+``8ae4f63`` averaged ``0.8109`` accuracy with a group-bootstrap interval of
+``0.8003`` to ``0.8214``. It uses a different reserved partition and is not a
+paired superiority test, but it does not indicate that the CatBoost
+improvement depends only on repeated surnames.

--- a/docs/source/kaggle_benchmarks.rst
+++ b/docs/source/kaggle_benchmarks.rst
@@ -90,6 +90,9 @@ campaign and subsequent confirmation attempts in the same campaign are
 rejected. Add ``--submit`` only for a frozen milestone from a clean git
 working tree. After any leaderboard result is observed, a later campaign is
 useful for iteration but is not an independent final performance test.
+For new submissions, the harness records the hyperparameters chosen without
+confirmation labels and refits that fixed candidate on all labeled training
+rows; it does not start a fresh tuning search while generating the CSV.
 
 Current Evidence Status
 -----------------------
@@ -97,11 +100,24 @@ Current Evidence Status
 The first official MAMUT submission used commit ``ca29cc8``,
 ``spaceship_inductive_v2``, and ``LGBMClassifier``. Five development folds
 averaged ``0.8064`` accuracy; the locked confirmation score was ``0.7967``;
-the Kaggle public score was ``0.79798`` (submission ``52996032``). It did not
-beat the repository owner's previous ``cat.csv`` score of ``0.80500``.
+the Kaggle public score was ``0.79798`` (submission ``52996032``).
+
+A post-leaderboard development campaign at commit ``1d4dd1c`` identified
+CatBoost as stronger than LightGBM on paired outer folds using
+``spaceship_inductive_v2`` (``0.8094`` versus ``0.8016`` mean accuracy).
+Its confirmation observation was ``0.8035`` and the resulting public Kaggle
+score was ``0.80617`` (submission ``52996964``), exceeding the repository
+owner's earlier ``cat.csv`` score of ``0.80500``. Because this iteration
+followed observation of a public score, it is useful evidence of improvement,
+not an independent final estimate. That submission predates the fixed-parameter
+refit rule described above; future submission artifacts record and refit the
+confirmation-selected hyperparameters explicitly.
 
 Audit interpretation: the official train/test files share surname values for
 ``87.9%`` of test rows but do not share exact passenger-group or cabin keys.
 The submitted recipe therefore used a legitimate competition-aligned surname
 signal, but did not exploit target-free family/group batch aggregates and did
-not establish superior competitive performance.
+did not establish superior competitive performance. In paired post-score
+development evaluation, adding those batch aggregates improved LightGBM only
+slightly and did not improve CatBoost; model-family choice accounted for the
+substantial measured gain.

--- a/docs/source/kaggle_benchmarks.rst
+++ b/docs/source/kaggle_benchmarks.rst
@@ -123,7 +123,7 @@ Audit interpretation: the official train/test files share surname values for
 ``87.9%`` of test rows but do not share exact passenger-group or cabin keys.
 The submitted recipe therefore used a legitimate competition-aligned surname
 signal, but did not exploit target-free family/group batch aggregates and did
-did not establish superior competitive performance. In paired post-score
+not establish superior competitive performance. In paired post-score
 development evaluation, adding those batch aggregates improved LightGBM only
 slightly and did not improve CatBoost; model-family choice accounted for the
 substantial measured gain.
@@ -133,3 +133,7 @@ A separate household-component-disjoint CatBoost development run at commit
 ``0.8003`` to ``0.8214``. It uses a different reserved partition and is not a
 paired superiority test, but it does not indicate that the CatBoost
 improvement depends only on repeated surnames.
+
+The best recorded MAMUT public score, ``0.80617``, should be interpreted as a
+credible auditable baseline result, not a leaderboard-leading result or an
+estimate of private-leaderboard rank.

--- a/docs/source/kaggle_benchmarks.rst
+++ b/docs/source/kaggle_benchmarks.rst
@@ -1,0 +1,100 @@
+Kaggle Benchmarks
+=================
+
+.. meta::
+   :description: Run reproducible MAMUT Spaceship Titanic benchmark studies with locked confirmation data and explicit Kaggle submission control.
+   :keywords: MAMUT Kaggle benchmark, Spaceship Titanic, grouped validation, tabular classification
+
+MAMUT includes a competition-specific benchmark harness for
+``spaceship-titanic``. It is designed to test the package against a realistic
+external dataset without confusing local validation with official Kaggle
+leaderboard results. No MAMUT leaderboard result should be claimed until an
+uploaded submission reference and public score are recorded.
+
+Protocol
+--------
+
+The default ``development`` stage reserves a deterministic, group-disjoint
+confirmation partition and excludes it from experimentation. Development runs
+use passenger-group-disjoint outer evaluation and nested, fold-local model
+selection. Only a frozen candidate may be run once with ``--stage
+confirmation``. A confirmation score is an observation of that candidate; it
+must not select a different model. Confirmation fits on development data
+without exposing reserved labels to candidate-reporting logic, then predicts
+the reserved partition once for the selected candidate.
+
+The default ``spaceship_inductive_v2`` recipe derives row-observable domain
+features including cabin structure, spending behavior, age groups, CryoSleep
+consistency, and family name. ``spaceship_cohort_v2`` additionally derives
+batch-level family and passenger-group sizes. It requires
+``--group-scope household_component`` so related surnames cannot cross
+validation folds. Older recipes remain available only for reproducibility.
+
+Reported development metrics include outer accuracy, fixed-baseline uplift,
+audit-only alternate-candidate deltas, and a group-bootstrap interval over
+recorded outer predictions. Alternate outer-holdout scores can inform the next
+development run, but are not retrospective model selection. The interval
+reflects evaluation-sample composition under the recorded fits; it is not a
+post-selection confirmation interval or proof of private leaderboard
+performance.
+
+Development Run
+---------------
+
+.. code-block:: sh
+
+   uv run python scripts/benchmark_kaggle.py spaceship-titanic \
+     --stage development \
+     --recipe spaceship_inductive_v2 \
+     --group-scope passenger \
+     --search-profile balanced \
+     --selection-strategy nested_cv \
+     --selection-cv-splits 3 \
+     --selection-cv-repeats 1 \
+     --runs 5 \
+     --n-iterations 3 \
+     --exclude-models SVC MLPClassifier KNeighborsClassifier \
+     --format markdown
+
+The command writes an ignored ``latest_results.json`` and
+``experiment_manifest.json`` under ``.cache/mamut/benchmark-results/``. The
+manifest records configuration, data hashes, source commit, branch, dirty-tree
+state, and protocol interpretation. Detailed results include the nested
+selection summary, fixed-baseline comparison, and explicitly labeled
+development holdout audit rows.
+
+Locked Confirmation and Submission
+----------------------------------
+
+After choosing a candidate from development evidence, run its configuration
+once on the reserved partition:
+
+.. code-block:: sh
+
+   uv run python scripts/benchmark_kaggle.py spaceship-titanic \
+     --stage confirmation \
+     --recipe spaceship_inductive_v2 \
+     --group-scope passenger \
+     --include-models CatBoostClassifier LGBMClassifier \
+     --selection-strategy nested_cv \
+     --selection-cv-splits 3 \
+     --selection-cv-repeats 1 \
+     --n-iterations 10 \
+     --write-submission
+
+``--write-submission`` is allowed only in the confirmation stage and produces
+a local CSV. The first confirmation evaluation writes a campaign marker and
+subsequent attempts are rejected, because it is no longer an unseen holdout.
+Add ``--submit`` only for a frozen milestone from a clean git working tree.
+The harness rejects dirty-tree uploads. Official Kaggle public
+scores must be documented separately from local evidence with the manifest,
+commit SHA, package version, and submission reference.
+
+Current Evidence Status
+-----------------------
+
+The existing ``0.7843`` accuracy result is a single-run, group-disjoint
+integrity smoke result from an earlier recipe and a restricted
+logistic-regression/random-forest candidate pool. It is not an official Kaggle
+score and not a competitive performance estimate. The v2 campaign must be run
+before making performance claims.

--- a/docs/source/kaggle_benchmarks.rst
+++ b/docs/source/kaggle_benchmarks.rst
@@ -11,24 +11,28 @@ external dataset without confusing local validation with official Kaggle
 leaderboard results. No MAMUT leaderboard result should be claimed until an
 uploaded submission reference and public score are recorded.
 
-Protocol
---------
+Protocol and Estimands
+----------------------
 
-The default ``development`` stage reserves a deterministic, group-disjoint
-confirmation partition and excludes it from experimentation. Development runs
-use passenger-group-disjoint outer evaluation and nested, fold-local model
-selection. Only a frozen candidate may be run once with ``--stage
-confirmation``. A confirmation score is an observation of that candidate; it
-must not select a different model. Confirmation fits on development data
-without exposing reserved labels to candidate-reporting logic, then predicts
-the reserved partition once for the selected candidate.
+The ``development`` stage reserves a deterministic confirmation partition and
+excludes it from model development within a campaign. Only a frozen candidate
+may be run once with ``--stage confirmation``. A confirmation score is an
+observation of that candidate; it must not select another model.
 
-The default ``spaceship_inductive_v2`` recipe derives row-observable domain
-features including cabin structure, spending behavior, age groups, CryoSleep
-consistency, and family name. ``spaceship_cohort_v2`` additionally derives
-batch-level family and passenger-group sizes. It requires
-``--group-scope household_component`` so related surnames cannot cross
-validation folds. Older recipes remain available only for reproducibility.
+Two evaluation estimands are deliberately available:
+
+* ``--recipe spaceship_competition_v3 --group-scope passenger`` estimates the
+  Kaggle task. Exact passenger groups remain disjoint, but surname categories
+  may recur across folds because the official Kaggle train/test files share
+  surnames extensively. Features such as batch family size remain target-free.
+* ``--recipe spaceship_cohort_v2 --group-scope household_component`` estimates
+  performance for entirely unseen surname-linked components. It is stricter
+  and should be used for deployment-oriented generalization claims.
+
+The earlier ``spaceship_inductive_v2`` recipe derives row-level domain
+features and surname category only; it omits the batch relational features
+available in the competition-aligned recipe. Older recipes remain available
+for reproducibility.
 
 Reported development metrics include outer accuracy, fixed-baseline uplift,
 audit-only alternate-candidate deltas, and a group-bootstrap interval over
@@ -45,23 +49,22 @@ Development Run
 
    uv run python scripts/benchmark_kaggle.py spaceship-titanic \
      --stage development \
-     --recipe spaceship_inductive_v2 \
+     --campaign-id spaceship-competition-v3 \
+     --recipe spaceship_competition_v3 \
      --group-scope passenger \
-     --search-profile balanced \
-     --selection-strategy nested_cv \
-     --selection-cv-splits 3 \
-     --selection-cv-repeats 1 \
+     --include-models LGBMClassifier \
+     --selection-strategy single_split \
      --runs 5 \
      --n-iterations 3 \
-     --exclude-models SVC MLPClassifier KNeighborsClassifier \
+     --max-runtime-seconds 900 \
      --format markdown
 
-The command writes an ignored ``latest_results.json`` and
-``experiment_manifest.json`` under ``.cache/mamut/benchmark-results/``. The
-manifest records configuration, data hashes, source commit, branch, dirty-tree
-state, and protocol interpretation. Detailed results include the nested
-selection summary, fixed-baseline comparison, and explicitly labeled
-development holdout audit rows.
+Each command writes immutable ``results.json`` and ``manifest.json`` files
+under ``.cache/mamut/benchmark-results/<competition>/<campaign>/<recipe>/<run>/``.
+The manifest records configuration, data hashes, source commit, branch,
+dirty-tree state, evaluation estimand, and train/test relational-overlap
+audit. ``--max-runtime-seconds`` is a soft budget checked between completed
+outer runs; a single model fit can exceed it.
 
 Locked Confirmation and Submission
 ----------------------------------
@@ -73,28 +76,32 @@ once on the reserved partition:
 
    uv run python scripts/benchmark_kaggle.py spaceship-titanic \
      --stage confirmation \
-     --recipe spaceship_inductive_v2 \
+     --campaign-id spaceship-competition-v3 \
+     --recipe spaceship_competition_v3 \
      --group-scope passenger \
-     --include-models CatBoostClassifier LGBMClassifier \
-     --selection-strategy nested_cv \
-     --selection-cv-splits 3 \
-     --selection-cv-repeats 1 \
-     --n-iterations 10 \
+     --include-models CatBoostClassifier \
+     --selection-strategy single_split \
+     --n-iterations 5 \
      --write-submission
 
 ``--write-submission`` is allowed only in the confirmation stage and produces
-a local CSV. The first confirmation evaluation writes a campaign marker and
-subsequent attempts are rejected, because it is no longer an unseen holdout.
-Add ``--submit`` only for a frozen milestone from a clean git working tree.
-The harness rejects dirty-tree uploads. Official Kaggle public
-scores must be documented separately from local evidence with the manifest,
-commit SHA, package version, and submission reference.
+a local CSV. The first confirmation evaluation writes a marker inside that
+campaign and subsequent confirmation attempts in the same campaign are
+rejected. Add ``--submit`` only for a frozen milestone from a clean git
+working tree. After any leaderboard result is observed, a later campaign is
+useful for iteration but is not an independent final performance test.
 
 Current Evidence Status
 -----------------------
 
-The existing ``0.7843`` accuracy result is a single-run, group-disjoint
-integrity smoke result from an earlier recipe and a restricted
-logistic-regression/random-forest candidate pool. It is not an official Kaggle
-score and not a competitive performance estimate. The v2 campaign must be run
-before making performance claims.
+The first official MAMUT submission used commit ``ca29cc8``,
+``spaceship_inductive_v2``, and ``LGBMClassifier``. Five development folds
+averaged ``0.8064`` accuracy; the locked confirmation score was ``0.7967``;
+the Kaggle public score was ``0.79798`` (submission ``52996032``). It did not
+beat the repository owner's previous ``cat.csv`` score of ``0.80500``.
+
+Audit interpretation: the official train/test files share surname values for
+``87.9%`` of test rows but do not share exact passenger-group or cabin keys.
+The submitted recipe therefore used a legitimate competition-aligned surname
+signal, but did not exploit target-free family/group batch aggregates and did
+not establish superior competitive performance.

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -23,15 +23,17 @@ Fit a Model
        n_iterations=1,
        optimization_method="random_search",
        holdout_size=0.2,
+       refit_final_model=True,
        random_state=42,
    )
    mamut.fit(X, y)
 
 MAMUT performs stratified train/validation splitting inside the modeling data,
 applies preprocessing, compares candidate classifiers, tunes their
-hyperparameters, and stores the validation-selected public prediction pipeline
-in ``mamut.best_model_``. The holdout split is kept out of selection and is
-used only for final evaluation.
+hyperparameters, and stores the selected public prediction pipeline in
+``mamut.best_model_``. With ``refit_final_model=True``, that pipeline is refit
+on all non-holdout modeling rows. The holdout split is kept out of selection
+and is used only for final evaluation.
 
 Predict
 -------
@@ -58,7 +60,8 @@ Inspect Results
 durations. ``training_summary_`` remains available as a backward-compatible
 alias.
 ``optuna_studies_`` stores the optimization study for each fitted model.
-``holdout_summary_`` contains final scores when holdout data is configured.
+``holdout_summary_`` contains holdout diagnostics when holdout data is
+configured; the selected-model row is the final refit score in this example.
 
 Generate a Report
 -----------------

--- a/docs/source/reports.rst
+++ b/docs/source/reports.rst
@@ -101,8 +101,9 @@ The report includes:
 * evidence-guided selection guidance
 * leakage risk checks
 * dummy, logistic regression, and random forest baseline comparison
-* repeated stratified cross-validation score stability with approximate score
-  intervals
+* repeated stratified cross-validation score stability, using group-disjoint
+  folds when groups were supplied, with descriptive resampling intervals that
+  are not confirmatory confidence intervals
 * ROC curve plots when ``save_plots=True``
 * confusion matrices when ``save_plots=True``
 * Optuna optimization history plots when studies are available

--- a/docs/source/user_guide.rst
+++ b/docs/source/user_guide.rst
@@ -38,23 +38,77 @@ arguments passed to ``Mamut`` are forwarded to
    )
 
 The preprocessing pipeline can handle missing numeric values, missing
-categorical values, one-hot encoding, skew correction, scaling, outlier
-filtering, imbalanced target resampling, optional feature selection, and
-optional PCA.
+categorical values, one-hot encoding, native categorical columns for supported
+boosting models, skew correction, scaling, optional outlier filtering,
+imbalanced target resampling, optional feature selection, and optional PCA.
+
+By default, ``preprocessing_profile="auto"`` lets each candidate use a
+model-aware preprocessing profile. Linear, kernel, and distance-based models
+use the generic one-hot path. Tree models use one-hot encoded categoricals
+without unnecessary numeric scaling. CatBoost and LightGBM use native
+categorical columns when compatible with the rest of the preprocessing options.
+Set ``preprocessing_profile="generic_ohe"`` to force the legacy shared one-hot
+path for every candidate.
+
+Automatic row removal for outliers is disabled by default because it can change
+the target distribution and hurt external validity. Enable it only when that is
+part of the intended experiment:
+
+.. code-block:: python
+
+   mamut = Mamut(outlier_removal=True)
 
 Model Search
 ------------
 
 MAMUT compares a set of supported classifiers and selects the best model by the
 configured score metric on a validation split. Supported model families include
-logistic regression, random forest, support vector machines, XGBoost,
+logistic regression, random forests, extremely randomized trees, histogram
+gradient boosting, XGBoost, LightGBM, CatBoost, support vector machines,
 multilayer perceptrons, Gaussian naive Bayes, and k-nearest neighbors.
 
-Use ``exclude_models`` to remove expensive or unwanted estimators by class name:
+Use ``search_profile`` to choose the candidate pool:
 
 .. code-block:: python
 
+   mamut = Mamut(search_profile="quick")      # small fast pool
+   mamut = Mamut(search_profile="balanced")   # default tabular pool
+   mamut = Mamut(search_profile="thorough")   # includes slower learners
+
+Use ``include_models`` for an exact candidate set, or ``exclude_models`` to
+remove expensive or unwanted estimators by class name:
+
+.. code-block:: python
+
+   mamut = Mamut(include_models=["RandomForestClassifier", "LGBMClassifier"])
    mamut = Mamut(exclude_models=["SVC", "MLPClassifier"])
+
+``include_models`` and ``exclude_models`` are mutually exclusive. Set
+``n_jobs`` to control parallelism for supported estimators.
+
+Selection Strategy
+------------------
+
+The default ``selection_strategy="single_split"`` keeps runtime low by choosing
+the best tuned candidate on one validation split. For higher-integrity model
+development, use nested validation over the non-holdout modeling data:
+
+.. code-block:: python
+
+   mamut = Mamut(
+       search_profile="balanced",
+       selection_strategy="nested_cv",
+       selection_cv_splits=5,
+       selection_cv_repeats=2,
+       selection_practical_margin=0.005,
+   )
+
+Nested-CV selection performs tuning inside every outer training fold, fits
+preprocessing inside those folds, and never uses final holdout rows. It selects
+by mean outer-fold score; models within the practical margin are treated as
+ties and resolved by lower score variance, then faster selection runtime.
+``selection_strategy="repeated_cv"`` is retained only as a deprecated alias.
+Inspect ``selection_summary_`` after ``fit`` to see the selection evidence.
 
 Hyperparameter Search
 ---------------------
@@ -117,6 +171,21 @@ You can also provide an explicit holdout set:
 Use holdout scores for final reporting. Use validation scores for model
 selection and debugging.
 
+When observations share a subject, household, session, patient, or other unit,
+pass group identifiers so no related rows cross validation boundaries:
+
+.. code-block:: python
+
+   mamut = Mamut(
+       selection_strategy="nested_cv",
+       holdout_size=0.2,
+       refit_final_model=True,
+   )
+   mamut.fit(X, y, groups=passenger_group)
+
+For an explicit holdout, also pass ``groups_holdout=``; overlapping modeling
+and holdout groups are rejected.
+
 Final Refit
 -----------
 
@@ -135,7 +204,9 @@ selection, set ``refit_final_model=True``:
    mamut.fit(X, y)
 
 The final refit never uses holdout rows. Use this option for deployment
-artifacts after you have accepted the validation and holdout diagnostics.
+artifacts after you have accepted validation diagnostics. With
+``selection_strategy="nested_cv"``, the selected model family is also retuned
+by cross-validation on all non-holdout modeling rows before the final fit.
 
 Prediction Contract
 -------------------
@@ -158,11 +229,13 @@ The evidence layer includes:
 
 * basic leakage checks for target-like columns, exact target copies, identifier
   columns, duplicate feature rows, and class imbalance
-* baseline comparison against dummy, logistic regression, and random forest
-  models
-* repeated stratified cross-validation for score stability
-* approximate t-intervals over repeated fold scores, clipped to the valid
-  metric range
+* comparison against fitted MAMUT candidates plus dummy, logistic regression,
+  and random forest baselines
+* repeated stratified cross-validation, or group-disjoint stratified folds when
+  ``groups=`` is supplied, for score stability
+* descriptive t-based stability intervals over repeated fold scores, clipped
+  to the valid metric range; these folds are dependent and the interval is not
+  a confirmatory confidence claim
 * evidence-guided selection guidance that confirms, challenges, or blocks trust
   in the validation-selected model
 
@@ -187,6 +260,16 @@ You can compute the evidence tables without writing a report:
    mamut.leakage_checks_
    mamut.selection_guidance_
 
+For a locked final holdout confirmation, avoid comparing alternate MAMUT
+candidates on that holdout:
+
+.. code-block:: python
+
+   evidence = mamut.generate_evidence(
+       dataset="holdout",
+       include_candidate_comparison=False,
+   )
+
 For lightweight evaluation in scripts or CI, disable expensive or file-writing
 outputs while keeping evidence generation enabled:
 
@@ -201,11 +284,13 @@ outputs while keeping evidence generation enabled:
 The score stability check refits the selected estimator and baseline models
 with fold-local preprocessing. It does not retune hyperparameters inside each
 fold, so treat it as a stability diagnostic rather than a full nested
-cross-validation benchmark.
+cross-validation benchmark. Use ``selection_strategy="nested_cv"`` when model
+selection itself needs nested evaluation.
 
 The evidence-guided selection table is intentionally conservative. If a
 baseline beats the selected model on final holdout data, MAMUT challenges the
-selection but does not silently promote the holdout winner. Use that challenge
+selection for review but keeps the selected candidate as the recommendation.
+It does not silently promote the holdout winner. Use that challenge
 to rerun model selection or reserve a new final holdout before deployment.
 
 For a reproducible example of these diagnostics on public sklearn datasets, see

--- a/mamut/evaluation.py
+++ b/mamut/evaluation.py
@@ -179,7 +179,6 @@ def _generate_ensemble_list(ensemble: Pipeline) -> str:
         return ""
     ensemble = _unwrap_public_model(ensemble.named_steps["model"])
     base_estimators = ensemble.estimators
-    meta = ensemble.final_estimator
     # Generate HTML list with ensemble contents:
     html_list = ""
 
@@ -188,7 +187,13 @@ def _generate_ensemble_list(ensemble: Pipeline) -> str:
         html_list += f"<li>{name}: {estimator.__class__.__name__}</li>"
     html_list += "</ul></li>"
 
-    html_list += f"<li><strong>Meta Model:</strong> <ul><li>{meta.__class__.__name__}</li></ul></li>"
+    if hasattr(ensemble, "final_estimator"):
+        meta = ensemble.final_estimator
+        html_list += f"<li><strong>Meta Model:</strong> <ul><li>{meta.__class__.__name__}</li></ul></li>"
+    else:
+        html_list += (
+            f"<li><strong>Voting:</strong> <ul><li>{ensemble.voting}</li></ul></li>"
+        )
 
     return html_list
 
@@ -218,8 +223,8 @@ class ModelEvaluator:
     def __init__(
         self,
         models: dict,
-        # X_evaluation and y_evaluation are preprocessed. X and y are not.
-        X_evaluation: np.ndarray,
+        # X_evaluation is in the input contract expected by ``models``.
+        X_evaluation,
         y_evaluation: np.ndarray,
         X_train: np.ndarray,
         y_train: np.ndarray,
@@ -235,6 +240,7 @@ class ModelEvaluator:
         preprocessing_steps,
         is_ensemble: bool,
         greedy_ensemble,
+        X_explanation=None,
         feature_names: Optional[List[str]] = None,
         excluded_models: List[str] = None,
         n_top_models: int = 3,
@@ -256,6 +262,7 @@ class ModelEvaluator:
         self.y_evaluation = y_evaluation
         self.X_train = X_train
         self.y_train = y_train
+        self.X_explanation = X_train if X_explanation is None else X_explanation
         self.optimizer = optimizer
         self.n_trials = n_trials
         self.metric = metric
@@ -433,14 +440,14 @@ class ModelEvaluator:
         save: bool = True,
     ) -> None:
         rows = math.ceil(n_top / 3)
-        fig = plt.figure(figsize=(18, 5 * rows))
+        fig = plt.figure(figsize=(18, 5 * rows), layout="constrained")
         top_models = training_summary["Model"].head(n_top).to_numpy()
         if n_top == 3:
-            gs = gridspec.GridSpec(1, 3, wspace=0.4)
+            gs = gridspec.GridSpec(1, 3, figure=fig, wspace=0.4)
         elif n_top > 3:
-            gs = gridspec.GridSpec(rows, 3, wspace=0.3, hspace=0.3)
+            gs = gridspec.GridSpec(rows, 3, figure=fig, wspace=0.3, hspace=0.3)
         else:
-            gs = gridspec.GridSpec(1, n_top, wspace=0.3, hspace=0.3)
+            gs = gridspec.GridSpec(1, n_top, figure=fig, wspace=0.3, hspace=0.3)
 
         for i, model_name in enumerate(top_models):
             model = next(
@@ -454,8 +461,6 @@ class ModelEvaluator:
             plt.title(f"{model_name}", fontsize=14)
             plt.xlabel("Predicted", fontsize=12)
             plt.ylabel("Actual", fontsize=12)
-
-        plt.tight_layout()
 
         if save:
             plt.savefig(
@@ -552,7 +557,11 @@ class ModelEvaluator:
 
     def _plot_shap_beeswarm(self, model, show: bool = False, save: bool = True) -> None:
         X_background = self._shap_background()
-        if model.__class__.__name__ in ["KNeighborsClassifier", "SVC", "MLPClassifier"]:
+        if hasattr(model, "preprocessor_") or model.__class__.__name__ in [
+            "KNeighborsClassifier",
+            "SVC",
+            "MLPClassifier",
+        ]:
             explainer = shap.Explainer(model.predict, X_background)
         else:
             explainer = shap.Explainer(model, X_background)
@@ -605,10 +614,10 @@ class ModelEvaluator:
     def _shap_background(self):
         if (
             self.shap_max_samples is None
-            or self.X_train.shape[0] <= self.shap_max_samples
+            or self.X_explanation.shape[0] <= self.shap_max_samples
         ):
-            return self.X_train
-        return self.X_train[: self.shap_max_samples]
+            return self.X_explanation
+        return self.X_explanation[: self.shap_max_samples]
 
     def _plot_pca_loadings(self, show: bool = False, save: bool = True) -> None:
         if self.pca_loadings is None:
@@ -830,7 +839,7 @@ class ModelEvaluator:
             plots_available=self.save_plots,
             shap_available=self.include_shap and self.save_plots,
             is_ensemble=self.is_ensemble,
-            ensemble_method="Stacking",
+            ensemble_method="Voting",
             ensemble_list=_generate_ensemble_list(self.greedy_ensemble),
             ensemble_summary=self._generate_greedy_ensemble_results_html(
                 self.greedy_ensemble

--- a/mamut/evidence.py
+++ b/mamut/evidence.py
@@ -16,7 +16,9 @@ from sklearn.metrics import (
     recall_score,
     roc_auc_score,
 )
-from sklearn.model_selection import RepeatedStratifiedKFold
+from sklearn.model_selection import RepeatedStratifiedKFold, StratifiedGroupKFold
+
+from mamut.model_selection import fit_estimator, make_preprocessor
 
 
 def default_baseline_estimators(random_state: Optional[int] = 42) -> dict:
@@ -137,9 +139,12 @@ def detect_leakage_risks(X: pd.DataFrame, y: pd.Series) -> pd.DataFrame:
         if n_conflicting:
             issues.append(
                 {
-                    "severity": "warning",
+                    "severity": "info",
                     "check": "duplicate_features_conflicting_targets",
-                    "message": f"{n_conflicting} duplicated feature pattern(s) have conflicting targets.",
+                    "message": (
+                        f"{n_conflicting} duplicated feature pattern(s) have conflicting "
+                        "targets; this is outcome ambiguity, not evidence of leakage."
+                    ),
                 }
             )
         else:
@@ -177,15 +182,26 @@ def build_evidence_report(
     preprocessor_factory: Callable,
     evaluation_dataset: str,
     holdout_available: bool,
+    groups: Optional[pd.Series] = None,
+    groups_train: Optional[pd.Series] = None,
+    groups_evaluation: Optional[pd.Series] = None,
     cv_splits: int = 5,
     cv_repeats: int = 3,
     confidence_level: float = 0.95,
     random_state: Optional[int] = 42,
     practical_margin: float = 0.01,
+    candidate_estimators: Optional[dict] = None,
 ) -> dict:
     selected_model_label = f"MAMUT Selected ({selected_estimator.__class__.__name__})"
+    candidate_estimators = candidate_estimators or {}
+    candidate_comparison_estimators = {
+        f"MAMUT Candidate ({model_name})": estimator
+        for model_name, estimator in candidate_estimators.items()
+        if estimator.__class__.__name__ != selected_estimator.__class__.__name__
+    }
     estimators = {
         selected_model_label: selected_estimator,
+        **candidate_comparison_estimators,
         **default_baseline_estimators(random_state=random_state),
     }
 
@@ -210,17 +226,34 @@ def build_evidence_report(
         cv_repeats=cv_repeats,
         confidence_level=confidence_level,
         random_state=random_state,
+        groups=groups,
     )
     leakage_checks = detect_leakage_risks(X, y if y_leakage is None else y_leakage)
+    group_overlap = np.nan
+    if groups_train is not None and groups_evaluation is not None:
+        group_overlap = len(set(groups_train).intersection(groups_evaluation))
     validation_integrity = pd.DataFrame(
         [
             {
                 "evaluation_dataset": evaluation_dataset,
                 "holdout_available": holdout_available,
-                "cv_strategy": "RepeatedStratifiedKFold",
+                "cv_strategy": (
+                    "RepeatedStratifiedGroupKFold"
+                    if groups is not None
+                    else "RepeatedStratifiedKFold"
+                ),
                 "cv_splits": score_stability.attrs.get("cv_splits", np.nan),
                 "cv_repeats": cv_repeats,
                 "confidence_level": confidence_level,
+                "interval_interpretation": (
+                    "Descriptive stability interval from dependent resampling scores; "
+                    "not a confirmatory confidence interval."
+                ),
+                "grouped_validation": groups is not None,
+                "n_groups": (
+                    int(pd.Series(groups).nunique()) if groups is not None else np.nan
+                ),
+                "evaluation_group_overlap": group_overlap,
                 "n_leakage_warnings": int(
                     leakage_checks["severity"].isin(["warning", "critical"]).sum()
                 ),
@@ -317,11 +350,17 @@ def build_selection_guidance(
     if critical_leakage:
         status = "blocked"
         recommended_model = selected_model_label
+        review_candidate = selected_model_label
         action = "Fix critical leakage risks before trusting model-selection evidence."
         reason = "At least one critical leakage risk was detected."
     elif split_challenge:
         status = "challenged"
-        recommended_model = split_challenger
+        review_candidate = split_challenger
+        recommended_model = (
+            selected_model_label
+            if evaluation_dataset == "holdout"
+            else split_challenger
+        )
         action = _challenge_action(evaluation_dataset)
         reason = (
             f"{split_challenger} outperformed the selected model on the "
@@ -329,7 +368,12 @@ def build_selection_guidance(
         )
     elif stability_challenge:
         status = "challenged_strong" if ci_separated else "challenged"
-        recommended_model = stability_challenger
+        review_candidate = stability_challenger
+        recommended_model = (
+            selected_model_label
+            if evaluation_dataset == "holdout"
+            else stability_challenger
+        )
         action = (
             "Prefer the challenger for review and rerun selection with repeated "
             "validation before changing the production candidate."
@@ -339,10 +383,11 @@ def build_selection_guidance(
             f"{stability_delta:.4f}."
         )
         if ci_separated:
-            reason += " Its confidence interval is separated above the selected model."
+            reason += " Its stability interval is separated above the selected model."
     elif stability_caution:
         status = "confirmed_with_caution"
         recommended_model = selected_model_label
+        review_candidate = stability_challenger
         action = (
             "The selected model remains competitive, but review the lower-variance "
             "alternative before deployment."
@@ -354,11 +399,13 @@ def build_selection_guidance(
     elif pd.isna(selected_split_score) or pd.isna(selected_stability_mean):
         status = "inconclusive"
         recommended_model = selected_model_label
+        review_candidate = selected_model_label
         action = "Evidence was incomplete; inspect failed baseline or stability rows."
         reason = "Selected model evidence contains missing scores."
     else:
         status = "confirmed"
         recommended_model = selected_model_label
+        review_candidate = selected_model_label
         action = "Selected model is competitive with evidence baselines."
         reason = (
             "No evidence baseline exceeded the selected model by the practical margin."
@@ -370,6 +417,7 @@ def build_selection_guidance(
                 "status": status,
                 "selected_model": selected_model_label,
                 "recommended_model": recommended_model,
+                "review_candidate": review_candidate,
                 "reason": reason,
                 "action": action,
                 "evaluation_dataset": evaluation_dataset,
@@ -443,6 +491,7 @@ def evaluate_estimators_on_split(
     for model_name, estimator in estimators.items():
         try:
             fitted_estimator, X_eval_transformed = _fit_estimator_with_preprocessing(
+                model_name=model_name,
                 estimator=estimator,
                 X_train=X_train,
                 y_train=y_train,
@@ -486,10 +535,15 @@ def repeated_stratified_cv_scores(
     cv_repeats: int = 3,
     confidence_level: float = 0.95,
     random_state: Optional[int] = 42,
+    groups: Optional[pd.Series] = None,
 ) -> pd.DataFrame:
-    y = pd.Series(y)
+    X = pd.DataFrame(X).reset_index(drop=True)
+    y = pd.Series(y).reset_index(drop=True)
+    groups = pd.Series(groups).reset_index(drop=True) if groups is not None else None
     min_class_count = int(y.value_counts().min())
     effective_splits = min(cv_splits, min_class_count)
+    if groups is not None:
+        effective_splits = min(effective_splits, int(groups.nunique()))
 
     if effective_splits < 2:
         rows = [
@@ -509,21 +563,34 @@ def repeated_stratified_cv_scores(
         result.attrs["cv_splits"] = effective_splits
         return result
 
-    splitter = RepeatedStratifiedKFold(
-        n_splits=effective_splits,
-        n_repeats=cv_repeats,
-        random_state=random_state,
-    )
+    if groups is None:
+        splitter = RepeatedStratifiedKFold(
+            n_splits=effective_splits,
+            n_repeats=cv_repeats,
+            random_state=random_state,
+        )
+        folds = list(splitter.split(X, y))
+    else:
+        folds = []
+        for repeat in range(cv_repeats):
+            repeat_seed = None if random_state is None else random_state + repeat
+            splitter = StratifiedGroupKFold(
+                n_splits=effective_splits,
+                shuffle=True,
+                random_state=repeat_seed,
+            )
+            folds.extend(splitter.split(X, y, groups))
     rows = []
 
     for model_name, estimator in estimators.items():
         scores = []
         status = "ok"
-        for train_idx, eval_idx in splitter.split(X, y):
+        for train_idx, eval_idx in folds:
             try:
                 fitted_estimator, X_eval_transformed = (
                     _fit_estimator_with_preprocessing(
                         estimator=estimator,
+                        model_name=model_name,
                         X_train=X.iloc[train_idx],
                         y_train=y.iloc[train_idx],
                         X_evaluation=X.iloc[eval_idx],
@@ -624,13 +691,14 @@ def score_estimator(estimator, X, y, metric_name: str, binary: bool) -> float:
 
 
 def _fit_estimator_with_preprocessing(
+    model_name: str,
     estimator,
     X_train: pd.DataFrame,
     y_train: pd.Series,
     X_evaluation: pd.DataFrame,
     preprocessor_factory: Callable,
 ):
-    preprocessor = preprocessor_factory()
+    preprocessor = make_preprocessor(preprocessor_factory, model_name)
     y_train = pd.Series(y_train, index=X_train.index)
 
     if preprocessor is not None:
@@ -650,5 +718,5 @@ def _fit_estimator_with_preprocessing(
         )
 
     fitted_estimator = clone(estimator)
-    fitted_estimator.fit(X_train_transformed, y_train_transformed)
+    fit_estimator(fitted_estimator, X_train_transformed, y_train_transformed)
     return fitted_estimator, X_eval_transformed

--- a/mamut/model_selection.py
+++ b/mamut/model_selection.py
@@ -1,15 +1,23 @@
 import ast
+import inspect
 import logging
 import time
 import warnings
 from copy import copy
+from dataclasses import dataclass
 from typing import Callable, List, Literal, Optional
 
 import numpy as np
 import optuna
 import pandas as pd
+from catboost import CatBoostClassifier  # noqa
+from lightgbm import LGBMClassifier  # noqa
 from optuna.samplers import RandomSampler, TPESampler
+from scipy import stats
+from sklearn.base import BaseEstimator, ClassifierMixin, clone
 from sklearn.ensemble import (  # noqa
+    ExtraTreesClassifier,
+    HistGradientBoostingClassifier,
     RandomForestClassifier,
     StackingClassifier,
     VotingClassifier,
@@ -25,29 +33,232 @@ from sklearn.metrics import (
     recall_score,
     roc_auc_score,
 )
-from sklearn.model_selection import StratifiedKFold
+from sklearn.model_selection import StratifiedGroupKFold, StratifiedKFold
 from sklearn.naive_bayes import GaussianNB  # noqa
 from sklearn.neighbors import KNeighborsClassifier  # noqa
 from sklearn.neural_network import MLPClassifier  # noqa
 from sklearn.svm import SVC  # noqa
 from xgboost import XGBClassifier  # noqa
 
-from mamut.utils.utils import adjust_search_spaces, model_param_dict, sample_parameter
+from mamut.preprocessing.preprocessing import Preprocessor
+from mamut.utils.utils import (
+    SEARCH_PROFILES,
+    adjust_search_spaces,
+    model_names_for_profile,
+    model_param_dict,
+    sample_parameter,
+)
 
 optuna.logging.set_verbosity(optuna.logging.WARNING)
 warnings.filterwarnings("ignore", category=ConvergenceWarning)
 
 log = logging.getLogger(__name__)
 
+
+@dataclass(frozen=True)
+class CandidateModel:
+    name: str
+    estimator_factory: Callable[[Optional[int], Optional[int]], object]
+    runtime_cost: Literal["low", "medium", "high"] = "medium"
+    supports_predict_proba: bool = True
+    preprocessing_profile: Literal["generic_ohe", "tree_ohe", "native_categorical"] = (
+        "generic_ohe"
+    )
+
+    def create(self, *, random_state: Optional[int], n_jobs: Optional[int]):
+        return self.estimator_factory(random_state, n_jobs)
+
+
+def _sklearn_factory(model_class, **default_params):
+    def factory(random_state: Optional[int], n_jobs: Optional[int]):
+        params = default_params.copy()
+        valid_params = model_class().get_params()
+        if random_state is not None and "random_state" in valid_params:
+            params.setdefault("random_state", random_state)
+        if n_jobs is not None and "n_jobs" in valid_params:
+            params.setdefault("n_jobs", n_jobs)
+        return model_class(**params)
+
+    return factory
+
+
+def _xgboost_factory(random_state: Optional[int], n_jobs: Optional[int]):
+    params = {
+        "eval_metric": "logloss",
+        "verbosity": 0,
+    }
+    if random_state is not None:
+        params["random_state"] = random_state
+    if n_jobs is not None:
+        params["n_jobs"] = n_jobs
+    return XGBClassifier(**params)
+
+
+def _lightgbm_factory(random_state: Optional[int], n_jobs: Optional[int]):
+    params = {
+        "verbosity": -1,
+    }
+    if random_state is not None:
+        params["random_state"] = random_state
+    if n_jobs is not None:
+        params["n_jobs"] = n_jobs
+    return LGBMClassifier(**params)
+
+
+def _catboost_factory(random_state: Optional[int], n_jobs: Optional[int]):
+    params = {
+        "allow_writing_files": False,
+        "verbose": False,
+    }
+    if random_state is not None:
+        params["random_seed"] = random_state
+    if n_jobs is not None:
+        params["thread_count"] = n_jobs
+    return CatBoostClassifier(**params)
+
+
 MODEL_REGISTRY = {
-    "LogisticRegression": LogisticRegression,
-    "RandomForestClassifier": RandomForestClassifier,
-    "SVC": SVC,
-    "XGBClassifier": XGBClassifier,
-    "MLPClassifier": MLPClassifier,
-    "GaussianNB": GaussianNB,
-    "KNeighborsClassifier": KNeighborsClassifier,
+    "LogisticRegression": CandidateModel(
+        "LogisticRegression", _sklearn_factory(LogisticRegression), runtime_cost="low"
+    ),
+    "RandomForestClassifier": CandidateModel(
+        "RandomForestClassifier",
+        _sklearn_factory(RandomForestClassifier),
+        runtime_cost="medium",
+        preprocessing_profile="tree_ohe",
+    ),
+    "ExtraTreesClassifier": CandidateModel(
+        "ExtraTreesClassifier",
+        _sklearn_factory(ExtraTreesClassifier),
+        runtime_cost="medium",
+        preprocessing_profile="tree_ohe",
+    ),
+    "HistGradientBoostingClassifier": CandidateModel(
+        "HistGradientBoostingClassifier",
+        _sklearn_factory(HistGradientBoostingClassifier),
+        runtime_cost="medium",
+        preprocessing_profile="tree_ohe",
+    ),
+    "SVC": CandidateModel("SVC", _sklearn_factory(SVC), runtime_cost="high"),
+    "XGBClassifier": CandidateModel(
+        "XGBClassifier",
+        _xgboost_factory,
+        runtime_cost="high",
+        preprocessing_profile="tree_ohe",
+    ),
+    "LGBMClassifier": CandidateModel(
+        "LGBMClassifier",
+        _lightgbm_factory,
+        runtime_cost="medium",
+        preprocessing_profile="native_categorical",
+    ),
+    "CatBoostClassifier": CandidateModel(
+        "CatBoostClassifier",
+        _catboost_factory,
+        runtime_cost="high",
+        preprocessing_profile="native_categorical",
+    ),
+    "MLPClassifier": CandidateModel(
+        "MLPClassifier", _sklearn_factory(MLPClassifier), runtime_cost="high"
+    ),
+    "GaussianNB": CandidateModel(
+        "GaussianNB", _sklearn_factory(GaussianNB), runtime_cost="low"
+    ),
+    "KNeighborsClassifier": CandidateModel(
+        "KNeighborsClassifier",
+        _sklearn_factory(KNeighborsClassifier),
+        runtime_cost="medium",
+    ),
 }
+
+
+def available_model_names() -> tuple[str, ...]:
+    return tuple(MODEL_REGISTRY)
+
+
+def preprocessing_profile_for_model(
+    model_name: str,
+) -> Literal["generic_ohe", "tree_ohe", "native_categorical"]:
+    return MODEL_REGISTRY[model_name].preprocessing_profile
+
+
+def categorical_feature_names(X) -> list:
+    if not isinstance(X, pd.DataFrame):
+        return []
+    return [
+        column
+        for column in X.columns
+        if any(
+            [
+                isinstance(X[column].dtype, pd.CategoricalDtype),
+                pd.api.types.is_object_dtype(X[column]),
+                pd.api.types.is_string_dtype(X[column]),
+                pd.api.types.is_bool_dtype(X[column]),
+            ]
+        )
+    ]
+
+
+def fit_estimator(estimator, X, y):
+    y = np.asarray(y).ravel()
+    if isinstance(estimator, CatBoostClassifier) and isinstance(X, pd.DataFrame):
+        cat_features = categorical_feature_names(X)
+        if cat_features:
+            estimator.fit(X, y, cat_features=cat_features)
+            return estimator
+    estimator.fit(X, y)
+    return estimator
+
+
+def make_preprocessor(preprocessor_factory: Optional[Callable], model_name: str):
+    if preprocessor_factory is None:
+        return None
+    signature = inspect.signature(preprocessor_factory)
+    if not signature.parameters:
+        return preprocessor_factory()
+    return preprocessor_factory(model_name)
+
+
+class CandidatePipelineClassifier(ClassifierMixin, BaseEstimator):
+    """Raw-input classifier that owns model-specific preprocessing."""
+
+    def __init__(
+        self,
+        estimator,
+        preprocess: bool = True,
+        profile: str = "generic_ohe",
+        preprocessor_kwargs: Optional[dict] = None,
+    ):
+        self.estimator = estimator
+        self.preprocess = preprocess
+        self.profile = profile
+        self.preprocessor_kwargs = preprocessor_kwargs
+
+    def fit(self, X, y):
+        kwargs = dict(self.preprocessor_kwargs or {})
+        kwargs["profile"] = self.profile
+        self.preprocessor_ = Preprocessor(**kwargs) if self.preprocess else None
+        if self.preprocessor_ is not None:
+            X_fit, y_fit = self.preprocessor_.fit_transform(
+                pd.DataFrame(X).copy(), pd.Series(y).copy()
+            )
+        else:
+            X_fit, y_fit = X, np.asarray(y)
+        self.estimator_ = clone(self.estimator)
+        fit_estimator(self.estimator_, X_fit, y_fit)
+        self.classes_ = self.estimator_.classes_
+        return self
+
+    def _transform(self, X):
+        if self.preprocessor_ is None:
+            return X
+        return self.preprocessor_.transform(pd.DataFrame(X).copy())
+
+    def predict(self, X):
+        return self.estimator_.predict(self._transform(X))
+
+    def predict_proba(self, X):
+        return self.estimator_.predict_proba(self._transform(X))
 
 
 class ModelSelector:
@@ -58,10 +269,19 @@ class ModelSelector:
         X_validation,
         y_validation,
         score_metric: Callable,
+        X_train_raw: Optional[pd.DataFrame] = None,
+        y_train_raw: Optional[pd.Series] = None,
+        X_validation_raw: Optional[pd.DataFrame] = None,
+        y_validation_raw: Optional[pd.Series] = None,
+        groups_train_raw: Optional[pd.Series] = None,
+        preprocessor_factory: Optional[Callable] = None,
         exclude_models: Optional[List[str]] = None,
+        include_models: Optional[List[str]] = None,
+        search_profile: Literal["quick", "balanced", "thorough"] = "balanced",
         optimization_method: Literal["random_search", "bayes"] = "bayes",
         n_iterations: int = 50,
         random_state: Optional[int] = 42,
+        n_jobs: Optional[int] = 1,
         verbose: bool = False,
     ):
 
@@ -69,13 +289,30 @@ class ModelSelector:
         self.y_train = np.asarray(y_train)
         self.X_validation = X_validation
         self.y_validation = np.asarray(y_validation)
-        if not exclude_models:
-            exclude_models = []
-
+        self.X_train_raw = X_train_raw
+        self.y_train_raw = pd.Series(y_train_raw) if y_train_raw is not None else None
+        self.X_validation_raw = X_validation_raw
+        self.y_validation_raw = (
+            pd.Series(y_validation_raw) if y_validation_raw is not None else None
+        )
+        self.groups_train_raw = (
+            pd.Series(groups_train_raw) if groups_train_raw is not None else None
+        )
+        self.preprocessor_factory = preprocessor_factory
+        self.base_score_metric = score_metric
+        self.search_profile = search_profile
+        self.optimization_method = optimization_method
+        self.n_jobs = n_jobs
+        self.model_names = self._resolve_model_names(
+            include_models=include_models,
+            exclude_models=exclude_models,
+            search_profile=search_profile,
+        )
         self.models = [
-            self._instantiate_model(model_name, random_state=random_state)
-            for model_name in model_param_dict.keys()
-            if model_name not in exclude_models
+            self._instantiate_model(
+                model_name, random_state=random_state, n_jobs=n_jobs
+            )
+            for model_name in self.model_names
         ]
         self.n_classes_ = len(np.unique(y_train))
         self.binary = True if self.n_classes_ == 2 else False
@@ -92,21 +329,93 @@ class ModelSelector:
         )
         self.n_iterations = n_iterations
         self.verbose = verbose
-        self.SKF_ = StratifiedKFold(n_splits=5, shuffle=True, random_state=random_state)
+        self.random_state = random_state
+        self.SKF_ = self._make_splitter(
+            self._cv_y(), groups=self.groups_train_raw, requested_splits=5
+        )
 
     @staticmethod
-    def _instantiate_model(model_name: str, random_state: Optional[int]):
-        model_class = MODEL_REGISTRY[model_name]
-        model = model_class()
-        if "random_state" in model.get_params():
-            return model_class(random_state=random_state)
-        return model
+    def _resolve_model_names(
+        *,
+        include_models: Optional[List[str]],
+        exclude_models: Optional[List[str]],
+        search_profile: str,
+    ) -> list[str]:
+        if search_profile not in SEARCH_PROFILES:
+            raise ValueError(
+                "search_profile must be one of: 'quick', 'balanced', 'thorough'."
+            )
+        if include_models and exclude_models:
+            raise ValueError("Use include_models or exclude_models, not both.")
+
+        if include_models:
+            candidate_names = list(include_models)
+        elif exclude_models:
+            candidate_names = list(available_model_names())
+        else:
+            candidate_names = list(model_names_for_profile(search_profile))
+        unknown_models = sorted(set(candidate_names) - set(available_model_names()))
+        if unknown_models:
+            valid_models = ", ".join(available_model_names())
+            raise ValueError(
+                f"Selected model names are unsupported: {unknown_models}. "
+                f"Valid model names are: {valid_models}."
+            )
+        if exclude_models:
+            candidate_names = [
+                model_name
+                for model_name in candidate_names
+                if model_name not in set(exclude_models)
+            ]
+        if not candidate_names:
+            raise ValueError("At least one supported model must be selected.")
+        return candidate_names
+
+    @staticmethod
+    def _instantiate_model(
+        model_name: str, random_state: Optional[int], n_jobs: Optional[int]
+    ):
+        return MODEL_REGISTRY[model_name].create(
+            random_state=random_state,
+            n_jobs=n_jobs,
+        )
 
     @staticmethod
     def _safe_index(data, idx):
         if hasattr(data, "iloc"):
             return data.iloc[idx]
         return data[idx]
+
+    @staticmethod
+    def _effective_cv_splits(y, requested_splits: int) -> int:
+        class_counts = pd.Series(y).value_counts()
+        if class_counts.empty:
+            raise ValueError("Cannot build stratified folds without target values.")
+        effective_splits = min(requested_splits, int(class_counts.min()))
+        if effective_splits < 2:
+            raise ValueError(
+                "At least two samples are required in every class for model selection."
+            )
+        return effective_splits
+
+    def _cv_y(self):
+        return self.y_train_raw if self.y_train_raw is not None else self.y_train
+
+    def _make_splitter(
+        self, y, groups=None, requested_splits: int = 5, repeat: int = 0
+    ):
+        effective_splits = self._effective_cv_splits(y, requested_splits)
+        seed = None if self.random_state is None else self.random_state + repeat
+        if groups is not None:
+            effective_splits = min(effective_splits, pd.Series(groups).nunique())
+            if effective_splits < 2:
+                raise ValueError("At least two groups are required for grouped CV.")
+            return StratifiedGroupKFold(
+                n_splits=effective_splits, shuffle=True, random_state=seed
+            )
+        return StratifiedKFold(
+            n_splits=effective_splits, shuffle=True, random_state=seed
+        )
 
     def _compute_score(self, score_metric, y_true, y_pred):
         y_true = np.asarray(y_true)
@@ -133,10 +442,11 @@ class ModelSelector:
         return score_metric(y_true, y_pred)
 
     def objective(self, trial, model):
-        if model.__class__.__name__ in model_param_dict:
-            param_grid = model_param_dict[model.__class__.__name__]
+        model_name = model.__class__.__name__
+        if model_name in model_param_dict:
+            param_grid = model_param_dict[model_name]
         else:
-            raise ValueError(f"Model {model.__class__.__name__} not supported")
+            raise ValueError(f"Model {model_name} not supported")
 
         param = {
             param_name: sample_parameter(trial, param_name, value)
@@ -145,20 +455,24 @@ class ModelSelector:
 
         param = adjust_search_spaces(param, model)
 
-        model.set_params(**param)
+        configured_model = clone(model).set_params(**param)
 
         cv_scores = []
-        for train_idx, val_idx in self.SKF_.split(self.X_train, self.y_train):
-            X_train_fold = self._safe_index(self.X_train, train_idx)
-            X_val_fold = self._safe_index(self.X_train, val_idx)
-            y_train_fold, y_val_fold = self.y_train[train_idx], self.y_train[val_idx]
+        X_for_split = self.X_train_raw if self.X_train_raw is not None else self.X_train
+        y_for_split = self._cv_y()
+        for train_idx, val_idx in self.SKF_.split(
+            X_for_split, y_for_split, self.groups_train_raw
+        ):
+            X_train_fold, y_train_fold, X_val_fold, y_val_fold = self._prepare_cv_fold(
+                train_idx, val_idx, model_name
+            )
 
-            model = model.__class__(**model.get_params())
-            model.fit(X_train_fold, y_train_fold)
+            fold_model = clone(configured_model)
+            fit_estimator(fold_model, X_train_fold, y_train_fold)
             val_pred = (
-                model.predict_proba(X_val_fold)
+                fold_model.predict_proba(X_val_fold)
                 if self.roc
-                else model.predict(X_val_fold)
+                else fold_model.predict(X_val_fold)
             )
             if self.binary and self.roc:
                 val_pred = val_pred[:, 1]
@@ -167,6 +481,34 @@ class ModelSelector:
         mean_cv_score = np.mean(cv_scores)
 
         return mean_cv_score
+
+    def _prepare_cv_fold(self, train_idx, val_idx, model_name: str):
+        if self.X_train_raw is None or self.preprocessor_factory is None:
+            X_train_fold = self._safe_index(self.X_train, train_idx)
+            X_val_fold = self._safe_index(self.X_train, val_idx)
+            y_train_fold = self.y_train[train_idx]
+            y_val_fold = self.y_train[val_idx]
+            return X_train_fold, y_train_fold, X_val_fold, y_val_fold
+
+        X_train_fold_raw = self.X_train_raw.iloc[train_idx]
+        X_val_fold_raw = self.X_train_raw.iloc[val_idx]
+        y_train_fold_raw = self.y_train_raw.iloc[train_idx]
+        y_val_fold = self.y_train_raw.iloc[val_idx].to_numpy()
+
+        preprocessor = make_preprocessor(self.preprocessor_factory, model_name)
+        if preprocessor is None:
+            return (
+                self._as_model_input(X_train_fold_raw),
+                y_train_fold_raw.to_numpy(),
+                self._as_model_input(X_val_fold_raw),
+                y_val_fold,
+            )
+
+        X_train_fold, y_train_fold = preprocessor.fit_transform(
+            X_train_fold_raw.copy(), y_train_fold_raw.copy()
+        )
+        X_val_fold = preprocessor.transform(X_val_fold_raw.copy())
+        return X_train_fold, np.asarray(y_train_fold), X_val_fold, y_val_fold
 
     def optimize_model(self, model):
         study = optuna.create_study(direction="maximize", sampler=self.optuna_sampler)
@@ -179,6 +521,7 @@ class ModelSelector:
         end_time = time.time()
         duration = end_time - start_time
         best_params = study.best_params
+        best_params = adjust_search_spaces(best_params, model)
         hidden_sizes = best_params.get("hidden_layer_sizes")
         if isinstance(hidden_sizes, str):
             try:
@@ -187,45 +530,152 @@ class ModelSelector:
                 pass
         return best_params, study.best_value, duration, study
 
+    def tune_and_fit_model(self, model_name: str):
+        model = self._instantiate_model(
+            model_name, random_state=self.random_state, n_jobs=self.n_jobs
+        )
+        params, score, duration, study = self.optimize_model(model)
+        fitted_model = clone(model).set_params(**params)
+        preprocessor = make_preprocessor(self.preprocessor_factory, model_name)
+        if preprocessor is None:
+            X_train = self._as_model_input(self.X_train_raw)
+            y_train = np.asarray(self.y_train_raw)
+        else:
+            X_train, y_train = preprocessor.fit_transform(
+                self.X_train_raw.copy(), self.y_train_raw.copy()
+            )
+        fit_estimator(fitted_model, X_train, np.asarray(y_train))
+        return fitted_model, preprocessor, score, duration, study
+
+    def nested_cv_selection_scores(
+        self,
+        *,
+        X: pd.DataFrame,
+        y: pd.Series,
+        groups: Optional[pd.Series],
+        cv_splits: int,
+        cv_repeats: int,
+        confidence_level: float,
+    ) -> pd.DataFrame:
+        rows = {model_name: [] for model_name in self.model_names}
+        durations = {model_name: 0.0 for model_name in self.model_names}
+        y = pd.Series(y).reset_index(drop=True)
+        X = pd.DataFrame(X).reset_index(drop=True)
+        groups = (
+            pd.Series(groups).reset_index(drop=True) if groups is not None else None
+        )
+        for repeat in range(cv_repeats):
+            splitter = self._make_splitter(
+                y, groups=groups, requested_splits=cv_splits, repeat=repeat
+            )
+            for train_idx, validation_idx in splitter.split(X, y, groups):
+                X_train = X.iloc[train_idx]
+                y_train = y.iloc[train_idx]
+                X_validation = X.iloc[validation_idx]
+                y_validation = y.iloc[validation_idx]
+                groups_train = groups.iloc[train_idx] if groups is not None else None
+                for model_name in self.model_names:
+                    start_time = time.time()
+                    selector = ModelSelector(
+                        X_train.to_numpy(),
+                        y_train.to_numpy(),
+                        X_validation.to_numpy(),
+                        y_validation.to_numpy(),
+                        score_metric=self.base_score_metric,
+                        X_train_raw=X_train,
+                        y_train_raw=y_train,
+                        X_validation_raw=X_validation,
+                        y_validation_raw=y_validation,
+                        groups_train_raw=groups_train,
+                        preprocessor_factory=self.preprocessor_factory,
+                        include_models=[model_name],
+                        search_profile=self.search_profile,
+                        optimization_method=self.optimization_method,
+                        n_iterations=self.n_iterations,
+                        random_state=(
+                            None
+                            if self.random_state is None
+                            else self.random_state + repeat
+                        ),
+                        n_jobs=self.n_jobs,
+                        verbose=self.verbose,
+                    )
+                    result = selector.compare_models()
+                    validation_summary = result[-2]
+                    rows[model_name].append(
+                        float(validation_summary.iloc[0][self.score_metric_name])
+                    )
+                    durations[model_name] += time.time() - start_time
+
+        summaries = []
+        for model_name, scores in rows.items():
+            summaries.append(
+                {
+                    "model": model_name,
+                    "metric": self.score_metric_name,
+                    **_summarize_scores(scores, confidence_level),
+                    "selection_duration": durations[model_name],
+                    "status": "ok",
+                }
+            )
+        return pd.DataFrame(summaries).sort_values(
+            by=["mean_score", "std_score", "selection_duration"],
+            ascending=[False, True, True],
+            na_position="last",
+        )
+
     def compare_models(self):
         best_model = None
         score_for_best_model = -np.inf
         params_for_best_model = None
         fitted_models = {}
+        fitted_preprocessors = {}
+        fitted_training_data = {}
+        fitted_validation_data = {}
         validation_summary = pd.DataFrame()
         studies = {}
 
         for model in self.models:
             log.info("Optimizing model: %s", model.__class__.__name__)
+            model_name = model.__class__.__name__
             params, score, duration, study = self.optimize_model(model)
             log.info(
                 "Best parameters for %s: %s, score: %.4f %s",
-                model.__class__.__name__,
+                model_name,
                 params,
                 score,
                 self.score_metric_name,
             )
 
-            model.set_params(**params)
-            model = model.__class__(**model.get_params())
-            model.fit(self.X_train, self.y_train)
-            fitted_models[model.__class__.__name__] = model
-            studies[model.__class__.__name__] = study
+            model = clone(model).set_params(**params)
+            (
+                X_train,
+                y_train,
+                X_validation,
+                y_validation,
+                preprocessor,
+            ) = self._prepare_final_model_data(model_name)
+            fit_estimator(model, X_train, y_train)
+            fitted_models[model_name] = model
+            fitted_preprocessors[model_name] = preprocessor
+            fitted_training_data[model_name] = (X_train, y_train)
+            fitted_validation_data[model_name] = (X_validation, y_validation)
+            studies[model_name] = study
 
             if self.roc:
                 if self.binary:
                     score_on_validation = self.score_metric(
-                        self.y_validation,
-                        model.predict_proba(self.X_validation)[:, 1],
+                        y_validation,
+                        model.predict_proba(X_validation)[:, 1],
                     )
                 else:
                     score_on_validation = self.score_metric(
-                        self.y_validation,
-                        model.predict_proba(self.X_validation),
+                        y_validation,
+                        model.predict_proba(X_validation),
                     )
             else:
                 score_on_validation = self.score_metric(
-                    self.y_validation, model.predict(self.X_validation)
+                    y_validation, model.predict(X_validation)
                 )
 
             if score_on_validation > score_for_best_model:
@@ -233,7 +683,9 @@ class ModelSelector:
                 best_model = model
                 params_for_best_model = params
 
-            scores_on_validation = self._score_model_with_metrics(model)
+            scores_on_validation = self._score_model_with_metrics(
+                model, X_validation, y_validation
+            )
 
             validation_summary = pd.concat(
                 [
@@ -241,7 +693,7 @@ class ModelSelector:
                     pd.DataFrame(
                         [
                             {
-                                "model": model.__class__.__name__,
+                                "model": model_name,
                                 **scores_on_validation,
                                 "duration": duration,
                             }
@@ -264,40 +716,87 @@ class ModelSelector:
             params_for_best_model,
             score_for_best_model,
             fitted_models,
+            fitted_preprocessors,
+            fitted_training_data,
+            fitted_validation_data,
             validation_summary,
             studies,
         )
 
-    def _score_model_with_metrics(self, fitted_model):
+    def _prepare_final_model_data(self, model_name: str):
+        if any(
+            [
+                self.X_train_raw is None,
+                self.X_validation_raw is None,
+                self.preprocessor_factory is None,
+            ]
+        ):
+            return (
+                self.X_train,
+                self.y_train,
+                self.X_validation,
+                self.y_validation,
+                None,
+            )
+
+        preprocessor = make_preprocessor(self.preprocessor_factory, model_name)
+        y_train_raw = self.y_train_raw.copy()
+        y_validation_raw = self.y_validation_raw.to_numpy()
+        if preprocessor is None:
+            return (
+                self._as_model_input(self.X_train_raw),
+                y_train_raw.to_numpy(),
+                self._as_model_input(self.X_validation_raw),
+                y_validation_raw,
+                None,
+            )
+
+        X_train, y_train = preprocessor.fit_transform(
+            self.X_train_raw.copy(), y_train_raw.copy()
+        )
+        X_validation = preprocessor.transform(self.X_validation_raw.copy())
+        return (
+            X_train,
+            np.asarray(y_train),
+            X_validation,
+            y_validation_raw,
+            preprocessor,
+        )
+
+    def _score_model_with_metrics(
+        self, fitted_model, X_validation=None, y_validation=None
+    ):
+        X_validation = self.X_validation if X_validation is None else X_validation
+        y_validation = (
+            self.y_validation if y_validation is None else np.asarray(y_validation)
+        )
         if not hasattr(fitted_model, "predict"):
             raise ValueError(
                 "The model is not fitted and can not be scored with any metric."
             )
 
-        y_pred = fitted_model.predict(self.X_validation)
-        y_pred_proba = fitted_model.predict_proba(self.X_validation)
+        y_pred = fitted_model.predict(X_validation)
+        y_pred_proba = fitted_model.predict_proba(X_validation)
         if self.binary:
             y_pred_proba = y_pred_proba[:, 1]
 
         results = {
-            "accuracy_score": accuracy_score(self.y_validation, y_pred),
-            "balanced_accuracy_score": balanced_accuracy_score(
-                self.y_validation, y_pred
-            ),
+            "accuracy_score": accuracy_score(y_validation, y_pred),
+            "balanced_accuracy_score": balanced_accuracy_score(y_validation, y_pred),
             "precision_score": precision_score(
-                self.y_validation, y_pred, average="weighted", zero_division=0
+                y_validation, y_pred, average="weighted", zero_division=0
             ),
             "recall_score": recall_score(
-                self.y_validation, y_pred, average="weighted", zero_division=0
+                y_validation, y_pred, average="weighted", zero_division=0
             ),
             "f1_score": f1_score(
-                self.y_validation, y_pred, average="weighted", zero_division=0
+                y_validation, y_pred, average="weighted", zero_division=0
             ),
             "jaccard_score": jaccard_score(
-                self.y_validation, y_pred, average="weighted", zero_division=0
+                y_validation, y_pred, average="weighted", zero_division=0
             ),
             "roc_auc_score": roc_auc_score(
-                self.y_validation,
+                y_validation,
                 y_pred_proba,
                 multi_class="ovr",
                 average="weighted",
@@ -309,3 +808,197 @@ class ModelSelector:
             **results,
         }
         return results
+
+    @staticmethod
+    def _as_model_input(data):
+        if isinstance(data, pd.DataFrame):
+            return data.to_numpy()
+        return data
+
+
+def repeated_cv_selection_scores(
+    *,
+    fitted_models: dict,
+    X: pd.DataFrame,
+    y: pd.Series,
+    metric_name: str,
+    binary: bool,
+    score_metric: Callable,
+    preprocessor_factory: Optional[Callable],
+    cv_splits: int,
+    cv_repeats: int,
+    confidence_level: float,
+    random_state: Optional[int],
+) -> pd.DataFrame:
+    y = pd.Series(y)
+    effective_splits = ModelSelector._effective_cv_splits(y, cv_splits)
+    rows = []
+
+    for model_name, estimator in fitted_models.items():
+        scores = []
+        start_time = time.time()
+        status = "ok"
+        for repeat in range(cv_repeats):
+            splitter = StratifiedKFold(
+                n_splits=effective_splits,
+                shuffle=True,
+                random_state=None if random_state is None else random_state + repeat,
+            )
+            for train_idx, val_idx in splitter.split(X, y):
+                try:
+                    X_train_fold, y_train_fold, X_val_fold, y_val_fold = (
+                        _prepare_raw_cv_fold(
+                            X=X,
+                            y=y,
+                            model_name=model_name,
+                            train_idx=train_idx,
+                            val_idx=val_idx,
+                            preprocessor_factory=preprocessor_factory,
+                        )
+                    )
+                    model = clone(estimator)
+                    fit_estimator(model, X_train_fold, y_train_fold)
+                    if metric_name == "roc_auc_score":
+                        predictions = model.predict_proba(X_val_fold)
+                        if binary:
+                            predictions = predictions[:, 1]
+                    else:
+                        predictions = model.predict(X_val_fold)
+                    scores.append(
+                        _compute_metric(
+                            score_metric, metric_name, binary, y_val_fold, predictions
+                        )
+                    )
+                except (
+                    Exception
+                ) as exc:  # pragma: no cover - data-dependent user edge cases
+                    status = f"failed: {exc.__class__.__name__}"
+                    scores = []
+                    break
+            if status != "ok":
+                break
+
+        score_summary = _summarize_scores(scores, confidence_level)
+        rows.append(
+            {
+                "model": model_name,
+                "metric": metric_name,
+                **score_summary,
+                "selection_duration": time.time() - start_time,
+                "status": status,
+            }
+        )
+
+    return pd.DataFrame(rows).sort_values(
+        by=["mean_score", "std_score", "selection_duration"],
+        ascending=[False, True, True],
+        na_position="last",
+    )
+
+
+def select_from_repeated_cv_summary(
+    summary: pd.DataFrame, practical_margin: float
+) -> str:
+    return repeated_cv_selection_decision(summary, practical_margin)["model"]
+
+
+def repeated_cv_selection_decision(
+    summary: pd.DataFrame, practical_margin: float
+) -> dict:
+    valid_summary = summary.loc[summary["status"].eq("ok")].dropna(
+        subset=["mean_score"]
+    )
+    if valid_summary.empty:
+        raise ValueError("No successful repeated-CV selection scores are available.")
+
+    best_mean = float(valid_summary["mean_score"].max())
+    contenders = valid_summary.loc[
+        valid_summary["mean_score"] >= best_mean - practical_margin
+    ].copy()
+    contenders = contenders.sort_values(
+        by=["std_score", "selection_duration", "model"],
+        ascending=[True, True, True],
+        na_position="last",
+    )
+    selected = contenders.iloc[0]
+    status = "close_call" if len(contenders) > 1 else "confirmed"
+    return {
+        "model": str(selected["model"]),
+        "status": status,
+        "best_mean_score": best_mean,
+        "n_contenders": int(len(contenders)),
+    }
+
+
+def _prepare_raw_cv_fold(
+    *,
+    X: pd.DataFrame,
+    y: pd.Series,
+    model_name: str,
+    train_idx,
+    val_idx,
+    preprocessor_factory: Optional[Callable],
+):
+    X_train_fold_raw = X.iloc[train_idx]
+    X_val_fold_raw = X.iloc[val_idx]
+    y_train_fold_raw = y.iloc[train_idx]
+    y_val_fold = y.iloc[val_idx].to_numpy()
+
+    if preprocessor_factory is None:
+        return (
+            ModelSelector._as_model_input(X_train_fold_raw),
+            y_train_fold_raw.to_numpy(),
+            ModelSelector._as_model_input(X_val_fold_raw),
+            y_val_fold,
+        )
+
+    preprocessor = make_preprocessor(preprocessor_factory, model_name)
+    if preprocessor is None:
+        return (
+            ModelSelector._as_model_input(X_train_fold_raw),
+            y_train_fold_raw.to_numpy(),
+            ModelSelector._as_model_input(X_val_fold_raw),
+            y_val_fold,
+        )
+
+    X_train_fold, y_train_fold = preprocessor.fit_transform(
+        X_train_fold_raw.copy(), y_train_fold_raw.copy()
+    )
+    X_val_fold = preprocessor.transform(X_val_fold_raw.copy())
+    return X_train_fold, np.asarray(y_train_fold), X_val_fold, y_val_fold
+
+
+def _compute_metric(score_metric, metric_name: str, binary: bool, y_true, predictions):
+    return score_metric(y_true, predictions)
+
+
+def _summarize_scores(scores, confidence_level: float) -> dict:
+    score_array = pd.Series(scores, dtype="float64").dropna().to_numpy()
+    n_scores = len(score_array)
+    if n_scores == 0:
+        return {
+            "mean_score": np.nan,
+            "std_score": np.nan,
+            "ci_low": np.nan,
+            "ci_high": np.nan,
+            "n_scores": 0,
+        }
+
+    mean_score = float(np.mean(score_array))
+    std_score = float(np.std(score_array, ddof=1)) if n_scores > 1 else 0.0
+    if n_scores > 1:
+        critical_value = stats.t.ppf((1 + confidence_level) / 2, df=n_scores - 1)
+        margin = critical_value * std_score / np.sqrt(n_scores)
+        ci_low = max(0.0, mean_score - margin)
+        ci_high = min(1.0, mean_score + margin)
+    else:
+        ci_low = mean_score
+        ci_high = mean_score
+
+    return {
+        "mean_score": mean_score,
+        "std_score": std_score,
+        "ci_low": ci_low,
+        "ci_high": ci_high,
+        "n_scores": n_scores,
+    }

--- a/mamut/preprocessing/preprocessing.py
+++ b/mamut/preprocessing/preprocessing.py
@@ -49,6 +49,8 @@ class Preprocessor:
         Whether to perform feature selection.
     pca : bool
         Whether to perform PCA for feature extraction.
+    outlier_removal : bool
+        Whether to remove rows flagged by IsolationForest during preprocessing.
     imbalanced_resampling : bool
         Whether to perform resampling to handle imbalanced data.
     resampling_strategy : Literal["SMOTE", "undersample", "combine"]
@@ -87,6 +89,10 @@ class Preprocessor:
         scaling: Literal["standard", "robust"] = "standard",
         feature_selection: bool = False,
         pca: bool = False,
+        profile: Literal[
+            "generic_ohe", "tree_ohe", "native_categorical"
+        ] = "generic_ohe",
+        outlier_removal: bool = False,
         imbalanced_resampling: bool = True,
         resampling_strategy: Literal["SMOTE", "undersample", "combine"] = "SMOTE",
         skew_threshold: float = 1,
@@ -114,6 +120,16 @@ class Preprocessor:
             Whether to perform feature selection.
         pca : bool
             Whether to perform PCA for feature extraction.
+        profile : Literal["generic_ohe", "tree_ohe", "native_categorical"]
+            Preprocessing family. ``generic_ohe`` keeps the legacy one-hot,
+            skew-correction, and scaling path. ``tree_ohe`` one-hot encodes
+            categoricals but skips numeric scaling/skew transforms.
+            ``native_categorical`` preserves pandas categorical columns for
+            estimators that support them.
+        outlier_removal : bool
+            Whether to remove rows flagged by IsolationForest. Disabled by
+            default because automatic row removal can change the target
+            distribution and hurt external validity.
         imbalanced_resampling : bool
             Whether to perform resampling to handle imbalanced data.
         resampling_strategy : Literal["SMOTE", "undersample", "combine"]
@@ -139,8 +155,20 @@ class Preprocessor:
         self.categorical_features = None
         self.num_imputation = num_imputation
         self.cat_imputation = cat_imputation
+        if profile not in {"generic_ohe", "tree_ohe", "native_categorical"}:
+            raise ValueError(
+                "profile must be one of: 'generic_ohe', 'tree_ohe', "
+                "'native_categorical'."
+            )
+        if profile == "native_categorical" and (feature_selection or pca):
+            raise ValueError(
+                "feature_selection and pca are not compatible with "
+                "native_categorical preprocessing."
+            )
         self.feature_selection = feature_selection
         self.pca = pca
+        self.profile = profile
+        self.outlier_removal = outlier_removal
         self.random_state = random_state
         self.scaling = scaling
         self.pca_threshold = pca_threshold
@@ -180,6 +208,18 @@ class Preprocessor:
         self.feature_names_out_ = None
 
         self._reset_fit_state()
+
+    @property
+    def _uses_native_categorical(self) -> bool:
+        return self.profile == "native_categorical"
+
+    @property
+    def _encodes_categorical(self) -> bool:
+        return not self._uses_native_categorical
+
+    @property
+    def _transforms_numeric_shape(self) -> bool:
+        return self.profile == "generic_ohe"
 
     def _reset_fit_state(self) -> None:
         self.numeric_features = (
@@ -295,6 +335,7 @@ class Preprocessor:
             self.n_missing_numeric = X[self.numeric_features].isnull().sum().sum()
             if self.n_missing_numeric > 0:
                 self.missing_numeric_ = True
+            if not self._uses_native_categorical:
                 X, self.missing_num_trans_ = handle_missing_numeric(
                     X, self.numeric_features, self.num_imputation
                 )
@@ -305,26 +346,35 @@ class Preprocessor:
             )
             if self.n_missing_categorical > 0:
                 self.missing_categorical_ = True
-                X, self.missing_cat_trans_ = handle_missing_categorical(
-                    X, self.categorical_features, self.cat_imputation
-                )
+            cat_imputation = (
+                "constant" if self._uses_native_categorical else self.cat_imputation
+            )
+            X, self.missing_cat_trans_ = handle_missing_categorical(
+                X, self.categorical_features, cat_imputation
+            )
 
         self.missing_ = self.missing_numeric_ or self.missing_categorical_
 
         if self.missing_:
             self.report_["imputation"] = {}
             if self.missing_numeric_:
-                self.report_["imputation"]["numeric"] = {
-                    "transformer": self.missing_num_trans_.__class__.__name__,
-                    "n_missing_numeric": self.n_missing_numeric,
-                }
+                if self.missing_num_trans_ is None:
+                    self.report_["imputation"]["numeric"] = {
+                        "policy": "preserved_for_native_estimator",
+                        "n_missing_numeric": self.n_missing_numeric,
+                    }
+                else:
+                    self.report_["imputation"]["numeric"] = {
+                        "transformer": self.missing_num_trans_.__class__.__name__,
+                        "n_missing_numeric": self.n_missing_numeric,
+                    }
             if self.missing_categorical_:
                 self.report_["imputation"]["categorical"] = {
                     "transformer": self.missing_cat_trans_.__class__.__name__,
                     "n_missing_categorical": self.n_missing_categorical,
                 }
 
-        if self.has_numeric_:
+        if self.has_numeric_ and self.outlier_removal:
             n_row_before = X.shape[0]
             X, y, self.outlier_trans_ = handle_outliers(
                 X, y, self.numeric_features, random_state=self.random_state
@@ -335,7 +385,7 @@ class Preprocessor:
                 "n_outliers_removed": n_row_before - n_row_after,
             }
 
-        if self.has_categorical_:
+        if self.has_categorical_ and self._encodes_categorical:
             X, self.cat_trans_, self.ohe_feature_names_ = handle_categorical(
                 X, self.categorical_features
             )
@@ -344,8 +394,16 @@ class Preprocessor:
                 "transformer": self.cat_trans_.__class__.__name__,
                 "encoded_feature_names": self.ohe_feature_names_,
             }
+        elif self.has_categorical_:
+            X = self._coerce_native_categorical(X)
+            self.report_["category_encoding"] = {
+                "transformer": "NativeCategoricalDtype",
+                "categorical_feature_names": self.categorical_features,
+            }
+        if self._uses_native_categorical and self.has_numeric_:
+            X = self._coerce_native_numeric(X)
 
-        if self.has_numeric_:
+        if self.has_numeric_ and self._transforms_numeric_shape:
             (
                 X,
                 self.skew_trans_,
@@ -362,7 +420,7 @@ class Preprocessor:
             self.skewed_feature_names_ = []
             self.lambdas_ = []
 
-        if self.has_numeric_:
+        if self.has_numeric_ and self._transforms_numeric_shape:
             X, self.scaler_ = handle_scaling(X, self.numeric_features, self.scaling)
             self.report_["scaling"] = {
                 "transformer": self.scaler_.__class__.__name__,
@@ -397,7 +455,13 @@ class Preprocessor:
                 "n_features_after": n_features_after,
             }
 
-        if self.imbalanced_resampling and self.imbalanced_:
+        if all(
+            [
+                self.imbalanced_resampling,
+                self.imbalanced_,
+                not self._uses_native_categorical,
+            ]
+        ):
             n_row_before = X.shape[0]
             X, y, self.imbalanced_trans_ = handle_imbalanced(
                 X, y, self.resampling_strategy, random_state=self.random_state
@@ -414,6 +478,12 @@ class Preprocessor:
                     "reason": "Insufficient minority samples for SMOTE.",
                     "strategy": self.resampling_strategy,
                 }
+        elif self.imbalanced_resampling and self.imbalanced_:
+            self.report_["imbalanced_resampling"] = {
+                "skipped": True,
+                "reason": "Native categorical preprocessing preserves raw feature types.",
+                "strategy": self.resampling_strategy,
+            }
 
         self.skewed_ = len(self.skewed_feature_names_) > 0
         if self.pca:
@@ -428,7 +498,7 @@ class Preprocessor:
             ]
         self.fitted = True
 
-        if isinstance(X, pd.DataFrame):
+        if isinstance(X, pd.DataFrame) and not self._uses_native_categorical:
             X = X.values
 
         if isinstance(y, pd.Series):
@@ -454,17 +524,17 @@ class Preprocessor:
         if not isinstance(X, pd.DataFrame):
             raise ValueError("Input data must be a pandas DataFrame.")
         X = X.copy()
-        if self.missing_numeric_:
+        if self.missing_num_trans_ is not None:
             X[self.numeric_features] = self.missing_num_trans_.transform(
                 X[self.numeric_features]
             )
 
-        if self.missing_categorical_:
+        if self.missing_cat_trans_ is not None:
             X[self.categorical_features] = self.missing_cat_trans_.transform(
                 X[self.categorical_features]
             )
 
-        if self.has_categorical_:
+        if self.has_categorical_ and self._encodes_categorical:
             encoded_features = self.cat_trans_.transform(X[self.categorical_features])
             encoded_features_df = pd.DataFrame(
                 encoded_features,
@@ -472,13 +542,17 @@ class Preprocessor:
                 index=X.index,
             )
             X = X.drop(columns=self.categorical_features).join(encoded_features_df)
+        elif self.has_categorical_:
+            X = self._coerce_native_categorical(X)
+        if self._uses_native_categorical and self.has_numeric_:
+            X = self._coerce_native_numeric(X)
 
         if self.skewed_:
             X[self.skewed_feature_names_] = self.skew_trans_.transform(
                 X[self.skewed_feature_names_]
             )
 
-        if self.has_numeric_:
+        if self.has_numeric_ and self.scaler_ is not None:
             X[self.numeric_features] = self.scaler_.transform(X[self.numeric_features])
 
         if self.feature_selection:
@@ -489,9 +563,23 @@ class Preprocessor:
         if self.pca:
             X = self.ext_trans_.transform(X)
 
-        if isinstance(X, pd.DataFrame):
+        if isinstance(X, pd.DataFrame) and not self._uses_native_categorical:
             X = X.values
 
+        return X
+
+    def _coerce_native_categorical(self, X: pd.DataFrame) -> pd.DataFrame:
+        X = X.copy()
+        for feature in self.categorical_features:
+            X[feature] = (
+                X[feature].astype("string").fillna("__missing__").astype("category")
+            )
+        return X
+
+    def _coerce_native_numeric(self, X: pd.DataFrame) -> pd.DataFrame:
+        X = X.copy()
+        for feature in self.numeric_features:
+            X[feature] = pd.to_numeric(X[feature], errors="coerce")
         return X
 
     def report(self):

--- a/mamut/utils/utils.py
+++ b/mamut/utils/utils.py
@@ -9,34 +9,80 @@ from sklearn.metrics import (
     roc_auc_score,
 )
 
+SEARCH_PROFILES = ("quick", "balanced", "thorough")
+
 lr_params = {
     "C": (1e-4, 1e4, "log"),
     "l1_ratio": (1e-4, 1.0, "log"),
-    "class_weight": (["balanced"], "categorical"),
+    "class_weight": ([None, "balanced"], "categorical"),
     "max_iter": (1000, 1000, "int"),
     "solver": (["saga", "lbfgs", "liblinear"], "categorical"),
 }
 
 tree_params = {
-    "n_estimators": (10, 1000, "int"),
+    "n_estimators": (100, 500, "int"),
     "criterion": (["gini", "entropy", "log_loss"], "categorical"),
     "bootstrap": ([True], "categorical"),
-    "max_samples": (0.5, 1, "float"),
-    "max_features": (0.1, 0.9, "float"),
-    "min_samples_leaf": (0.05, 0.25, "float"),
+    "max_depth": ([None, 5, 10, 20, 30], "categorical"),
+    "max_features": (["sqrt", "log2", None], "categorical"),
+    "min_samples_leaf": (1, 10, "int"),
+    "min_samples_split": (2, 20, "int"),
+    "class_weight": ([None, "balanced_subsample"], "categorical"),
+}
+
+extra_trees_params = {
+    "n_estimators": (100, 500, "int"),
+    "criterion": (["gini", "entropy", "log_loss"], "categorical"),
+    "max_depth": ([None, 5, 10, 20, 30], "categorical"),
+    "max_features": (["sqrt", "log2", None], "categorical"),
+    "min_samples_leaf": (1, 10, "int"),
+    "min_samples_split": (2, 20, "int"),
+    "class_weight": ([None, "balanced"], "categorical"),
+}
+
+hist_gradient_boosting_params = {
+    "max_iter": (50, 250, "int"),
+    "learning_rate": (0.01, 0.2, "log"),
+    "max_leaf_nodes": (15, 63, "int"),
+    "max_depth": ([None, 3, 5, 8, 12], "categorical"),
+    "min_samples_leaf": (10, 50, "int"),
+    "l2_regularization": (1e-6, 10.0, "log"),
+    "class_weight": ([None, "balanced"], "categorical"),
 }
 
 xgb_params = {
-    "n_estimators": (10, 1000, "int"),
-    "learning_rate": (1e-4, 0.4, "log"),
-    "subsample": (0.25, 1.0, "float"),
+    "n_estimators": (50, 500, "int"),
+    "learning_rate": (0.01, 0.3, "log"),
+    "subsample": (0.5, 1.0, "float"),
     "booster": (["gbtree"], "categorical"),
-    "max_depth": (1, 15, "int"),
-    "min_child_weight": (1, 128, "float"),
-    "colsample_bytree": (0.2, 1.0, "float"),
-    "colsample_bylevel": (0.2, 1.0, "float"),
-    "reg_alpha": (1e-4, 512.0, "log"),
-    "reg_lambda": (1e-3, 1e3, "log"),
+    "max_depth": (2, 8, "int"),
+    "min_child_weight": (1, 20, "float"),
+    "colsample_bytree": (0.5, 1.0, "float"),
+    "colsample_bylevel": (0.5, 1.0, "float"),
+    "reg_alpha": (1e-6, 10.0, "log"),
+    "reg_lambda": (1e-3, 100.0, "log"),
+}
+
+lightgbm_params = {
+    "n_estimators": (50, 500, "int"),
+    "learning_rate": (0.01, 0.3, "log"),
+    "num_leaves": (15, 127, "int"),
+    "max_depth": ([-1, 3, 5, 8, 12], "categorical"),
+    "min_child_samples": (5, 60, "int"),
+    "subsample": (0.5, 1.0, "float"),
+    "colsample_bytree": (0.5, 1.0, "float"),
+    "reg_alpha": (1e-6, 10.0, "log"),
+    "reg_lambda": (1e-3, 100.0, "log"),
+    "class_weight": ([None, "balanced"], "categorical"),
+}
+
+catboost_params = {
+    "iterations": (50, 500, "int"),
+    "learning_rate": (0.01, 0.3, "log"),
+    "depth": (3, 8, "int"),
+    "l2_leaf_reg": (1e-2, 20.0, "log"),
+    "random_strength": (1e-3, 10.0, "log"),
+    "border_count": (32, 255, "int"),
 }
 
 svc_params = {
@@ -70,15 +116,51 @@ knn_params = {
     "n_neighbors": (1, 30, "int"),
 }
 
-model_param_dict = {
+MODEL_SEARCH_SPACES = {
     "LogisticRegression": lr_params,
     "RandomForestClassifier": tree_params,
+    "ExtraTreesClassifier": extra_trees_params,
+    "HistGradientBoostingClassifier": hist_gradient_boosting_params,
     "SVC": svc_params,
     "XGBClassifier": xgb_params,
+    "LGBMClassifier": lightgbm_params,
+    "CatBoostClassifier": catboost_params,
     "MLPClassifier": mlp_params,
     "GaussianNB": gnb_params,
     "KNeighborsClassifier": knn_params,
 }
+
+QUICK_MODEL_NAMES = (
+    "LogisticRegression",
+    "RandomForestClassifier",
+    "ExtraTreesClassifier",
+    "GaussianNB",
+)
+BALANCED_MODEL_NAMES = (
+    "LogisticRegression",
+    "RandomForestClassifier",
+    "ExtraTreesClassifier",
+    "HistGradientBoostingClassifier",
+    "XGBClassifier",
+    "LGBMClassifier",
+    "CatBoostClassifier",
+    "GaussianNB",
+)
+THOROUGH_MODEL_NAMES = tuple(MODEL_SEARCH_SPACES)
+
+# Backward-compatible alias used by older tests and users for introspection.
+model_param_dict = MODEL_SEARCH_SPACES
+
+
+def model_names_for_profile(profile: str) -> tuple[str, ...]:
+    if profile == "quick":
+        return QUICK_MODEL_NAMES
+    if profile == "balanced":
+        return BALANCED_MODEL_NAMES
+    if profile == "thorough":
+        return THOROUGH_MODEL_NAMES
+    raise ValueError("search_profile must be one of: quick, balanced, thorough.")
+
 
 metric_dict = {
     "accuracy": accuracy_score,
@@ -159,6 +241,6 @@ def adjust_search_spaces(param_dict, model):
             param_dict["penalty"] = "elasticnet"
         else:
             param_dict["penalty"] = "l2"
-            param_dict["l1_ratio"] = None
+            param_dict.pop("l1_ratio", None)
 
     return param_dict

--- a/mamut/wrapper.py
+++ b/mamut/wrapper.py
@@ -1,18 +1,14 @@
 import logging
 import os
 import time
-from copy import copy
+import warnings
 from typing import List, Literal, Optional
 
 import joblib
 import numpy as np
 import pandas as pd
 from sklearn.base import BaseEstimator, ClassifierMixin, clone
-from sklearn.ensemble import (
-    RandomForestClassifier,
-    StackingClassifier,
-    VotingClassifier,
-)
+from sklearn.ensemble import VotingClassifier
 from sklearn.metrics import (
     accuracy_score,
     balanced_accuracy_score,
@@ -22,21 +18,28 @@ from sklearn.metrics import (
     recall_score,
     roc_auc_score,
 )
-from sklearn.model_selection import train_test_split
+from sklearn.model_selection import GroupShuffleSplit, train_test_split
 from sklearn.pipeline import Pipeline
 from sklearn.preprocessing import LabelEncoder
 
 from mamut.evidence import build_evidence_report
 from mamut.preprocessing.preprocessing import Preprocessor
-from mamut.utils.utils import metric_dict, model_param_dict
+from mamut.utils.utils import metric_dict
 
 from .evaluation import ModelEvaluator
-from .model_selection import ModelSelector
+from .model_selection import (
+    CandidatePipelineClassifier,
+    ModelSelector,
+    available_model_names,
+    fit_estimator,
+    preprocessing_profile_for_model,
+    repeated_cv_selection_decision,
+)
 
 log = logging.getLogger(__name__)
 
 
-class LabelDecodedClassifier(BaseEstimator, ClassifierMixin):
+class LabelDecodedClassifier(ClassifierMixin, BaseEstimator):
     """Wrap an encoded-label classifier so public predictions use original labels."""
 
     def __init__(self, estimator, label_encoder):
@@ -45,13 +48,13 @@ class LabelDecodedClassifier(BaseEstimator, ClassifierMixin):
 
     def fit(self, X, y):
         y_encoded = self.label_encoder.transform(y)
-        self.estimator.fit(X, y_encoded)
+        fit_estimator(self.estimator, X, y_encoded)
         return self
 
     def predict(self, X):
         encoded_predictions = self.estimator.predict(X)
         return self.label_encoder.inverse_transform(
-            np.asarray(encoded_predictions).astype(int)
+            np.asarray(encoded_predictions).astype(int).ravel()
         )
 
     def predict_proba(self, X):
@@ -148,6 +151,7 @@ class Mamut:
         preprocess: bool = True,
         imb_threshold: float = 0.10,
         exclude_models: Optional[List[str]] = None,
+        include_models: Optional[List[str]] = None,
         score_metric: Literal[
             "accuracy",
             "precision",
@@ -157,9 +161,18 @@ class Mamut:
             "jaccard",
             "roc_auc_score",
         ] = "f1",
+        search_profile: Literal["quick", "balanced", "thorough"] = "balanced",
         optimization_method: Literal["random_search", "bayes"] = "bayes",
         n_iterations: int = 30,
         random_state: Optional[int] = 42,
+        n_jobs: Optional[int] = 1,
+        selection_strategy: Literal[
+            "single_split", "nested_cv", "repeated_cv"
+        ] = "single_split",
+        selection_cv_splits: int = 5,
+        selection_cv_repeats: int = 2,
+        selection_practical_margin: float = 0.005,
+        preprocessing_profile: Literal["auto", "generic_ohe"] = "auto",
         validation_size: float = 0.2,
         holdout_size: Optional[float] = None,
         save_models: bool = False,
@@ -183,14 +196,37 @@ class Mamut:
             Threshold for detecting imbalanced data.
         exclude_models : Optional[List[str]]
             List of models to exclude from selection.
+        include_models : Optional[List[str]]
+            Optional exact list of models to include. Mutually exclusive with
+            exclude_models.
         score_metric : Literal["accuracy", "precision", "recall", "f1", "balanced_accuracy", "jaccard", "roc_auc_score"]
             Metric used to evaluate model performance.
+        search_profile : Literal["quick", "balanced", "thorough"]
+            Candidate set to search when include_models is not supplied.
         optimization_method : Literal["random_search", "bayes"]
             Method for hyperparameter optimization.
         n_iterations : Optional[int]
             Number of iterations for optimization.
         random_state : Optional[int]
             Random state for reproducibility.
+        n_jobs : Optional[int]
+            Number of worker threads for supported estimators. Use None to
+            keep estimator defaults.
+        selection_strategy : Literal["single_split", "nested_cv", "repeated_cv"]
+            Whether to select the final candidate by one validation split or
+            by nested CV over non-holdout modeling data. ``repeated_cv`` is a
+            deprecated alias for ``nested_cv``.
+        selection_cv_splits : int
+            Number of stratified folds for repeated-CV selection.
+        selection_cv_repeats : int
+            Number of repeats for repeated-CV selection.
+        selection_practical_margin : float
+            Maximum mean-score difference treated as a practical tie before
+            preferring lower score variance and faster runtime.
+        preprocessing_profile : Literal["auto", "generic_ohe"]
+            ``auto`` lets each candidate use a model-aware preprocessing
+            profile. ``generic_ohe`` preserves the legacy shared one-hot
+            preprocessing behavior.
         validation_size : float
             Fraction of the modeling data reserved for model selection.
         holdout_size : Optional[float]
@@ -219,9 +255,32 @@ class Mamut:
             raise ValueError(
                 "optimization_method must be one of: 'random_search', 'bayes'."
             )
+        if search_profile not in {"quick", "balanced", "thorough"}:
+            raise ValueError(
+                "search_profile must be one of: 'quick', 'balanced', 'thorough'."
+            )
         if not isinstance(n_iterations, int) or n_iterations < 1:
             raise ValueError(
                 "n_iterations must be an integer greater than or equal to 1."
+            )
+        if n_jobs is not None and (
+            not isinstance(n_jobs, int) or n_jobs == 0 or n_jobs < -1
+        ):
+            raise ValueError("n_jobs must be None, -1, or a positive integer.")
+        if selection_strategy not in {"single_split", "nested_cv", "repeated_cv"}:
+            raise ValueError(
+                "selection_strategy must be one of: 'single_split', 'nested_cv', "
+                "'repeated_cv'."
+            )
+        if selection_cv_splits < 2:
+            raise ValueError("selection_cv_splits must be at least 2.")
+        if selection_cv_repeats < 1:
+            raise ValueError("selection_cv_repeats must be at least 1.")
+        if selection_practical_margin < 0:
+            raise ValueError("selection_practical_margin must be non-negative.")
+        if preprocessing_profile not in {"auto", "generic_ohe"}:
+            raise ValueError(
+                "preprocessing_profile must be one of: 'auto', 'generic_ohe'."
             )
         self._validate_split_size(validation_size, "validation_size")
         if holdout_size is not None:
@@ -236,25 +295,43 @@ class Mamut:
             )
         if evidence_practical_margin < 0:
             raise ValueError("evidence_practical_margin must be non-negative.")
-        exclude_models = exclude_models or []
-        unknown_models = sorted(set(exclude_models) - set(model_param_dict))
+        if include_models and exclude_models:
+            raise ValueError("Use include_models or exclude_models, not both.")
+        known_models = set(available_model_names())
+        exclude_models = list(exclude_models or [])
+        include_models = list(include_models) if include_models is not None else None
+        unknown_models = sorted(set(exclude_models) - known_models)
         if unknown_models:
-            valid_models = ", ".join(model_param_dict)
+            valid_models = ", ".join(available_model_names())
             raise ValueError(
                 f"exclude_models contains unsupported model names: {unknown_models}. "
                 f"Valid model names are: {valid_models}."
             )
-        if len(exclude_models) >= len(model_param_dict):
-            raise ValueError("exclude_models cannot remove every supported model.")
+        if include_models is not None:
+            unknown_models = sorted(set(include_models) - known_models)
+            if unknown_models:
+                valid_models = ", ".join(available_model_names())
+                raise ValueError(
+                    f"include_models contains unsupported model names: {unknown_models}. "
+                    f"Valid model names are: {valid_models}."
+                )
 
         self.preprocess = preprocess
         self.imb_threshold = imb_threshold
         self.exclude_models = exclude_models
+        self.include_models = include_models
         self.score_metric = metric_dict[score_metric]
         self.score_metric_name = self.score_metric.__name__
+        self.search_profile = search_profile
         self.optimization_method = optimization_method
         self.n_iterations = n_iterations
         self.random_state = random_state
+        self.n_jobs = n_jobs
+        self.selection_strategy = selection_strategy
+        self.selection_cv_splits = selection_cv_splits
+        self.selection_cv_repeats = selection_cv_repeats
+        self.selection_practical_margin = selection_practical_margin
+        self.preprocessing_profile = preprocessing_profile
         self.validation_size = validation_size
         self.holdout_size = holdout_size
         self.save_models = save_models
@@ -266,8 +343,12 @@ class Mamut:
         self.evidence_confidence_level = evidence_confidence_level
         self.evidence_practical_margin = evidence_practical_margin
         self.preprocessor_kwargs = preprocessor_kwargs.copy()
+        self.preprocessor_kwargs.setdefault("imbalance_threshold", imb_threshold)
+        self.imb_threshold = self.preprocessor_kwargs["imbalance_threshold"]
 
-        self.preprocessor = Preprocessor(**preprocessor_kwargs) if preprocess else None
+        self.preprocessor = (
+            Preprocessor(**self.preprocessor_kwargs) if preprocess else None
+        )
         self.le = LabelEncoder()
         self.model_selector = None
 
@@ -289,12 +370,21 @@ class Mamut:
         self.y_validation_raw_ = None
         self.X_holdout_raw_ = None
         self.y_holdout_original_ = None
+        self.groups_ = None
+        self.groups_modeling_ = None
+        self.groups_train_ = None
+        self.groups_validation_ = None
+        self.groups_holdout_ = None
         self.X_test = None
         self.y_test = None
         self.binary = None
         self.roc = None
 
         self.raw_fitted_models_ = None
+        self.candidate_pipelines_ = None
+        self.fitted_preprocessors_ = None
+        self.fitted_training_data_ = None
+        self.fitted_validation_data_ = None
         self.fitted_models_ = None
         self.selected_estimator_ = None
         self.validation_selected_estimator_ = None
@@ -308,6 +398,7 @@ class Mamut:
         self.validation_summary_ = None
         self.holdout_summary_ = None
         self.training_summary_ = None
+        self.selection_summary_ = None
         self.optuna_studies_ = None
         self.models_output_path_ = None
         self.evidence_report_ = None
@@ -316,6 +407,7 @@ class Mamut:
         self.baseline_comparison_ = None
         self.score_stability_ = None
         self.selection_guidance_ = None
+        self.selection_summary_ = None
         self.report_result_ = None
 
         self.ensemble_ = None
@@ -329,6 +421,8 @@ class Mamut:
         y: pd.Series,
         X_holdout: Optional[pd.DataFrame] = None,
         y_holdout: Optional[pd.Series] = None,
+        groups: Optional[pd.Series] = None,
+        groups_holdout: Optional[pd.Series] = None,
     ):
         """
         Fits the model to the data.
@@ -345,6 +439,11 @@ class Mamut:
         y_holdout : Optional[pd.Series]
             Optional final holdout target. Holdout rows are never used for
             model or ensemble selection.
+        groups : Optional[pd.Series]
+            Group labels for observations that must remain in the same fold.
+        groups_holdout : Optional[pd.Series]
+            Group labels for explicit holdout rows. Required with ``groups``
+            and explicit holdout data so overlap can be rejected.
 
         Returns
         -------
@@ -356,6 +455,14 @@ class Mamut:
         if X_holdout is not None and self.holdout_size is not None:
             raise ValueError(
                 "Use either holdout_size or explicit X_holdout/y_holdout, not both."
+            )
+        if groups_holdout is not None and X_holdout is None:
+            raise ValueError("groups_holdout requires explicit X_holdout/y_holdout.")
+        if groups_holdout is not None and groups is None:
+            raise ValueError("groups_holdout requires groups.")
+        if X_holdout is not None and groups is not None and groups_holdout is None:
+            raise ValueError(
+                "groups_holdout is required with groups and explicit holdout data."
             )
 
         self.preprocessor = (
@@ -379,6 +486,15 @@ class Mamut:
         self.validation_selected_estimator_ = None
         self.final_preprocessor_ = None
         self.final_estimator_ = None
+        self.fitted_preprocessors_ = None
+        self.fitted_training_data_ = None
+        self.fitted_validation_data_ = None
+        self.candidate_pipelines_ = None
+        self.groups_ = None
+        self.groups_modeling_ = None
+        self.groups_train_ = None
+        self.groups_validation_ = None
+        self.groups_holdout_ = None
         self.imbalanced_ = False
 
         Mamut._check_categorical(y)
@@ -392,10 +508,18 @@ class Mamut:
             index=X.index,
             name=y_original.name,
         )
+        groups_encoded = None
+        if groups is not None:
+            if len(groups) != len(X):
+                raise ValueError("groups must have the same length as X.")
+            groups_encoded = pd.Series(groups).copy()
+            groups_encoded.index = X.index
+        self.groups_ = groups_encoded
 
         X_modeling = X.copy()
         y_modeling = y_encoded.copy()
         y_modeling_original = y_original.copy()
+        groups_modeling = groups_encoded.copy() if groups_encoded is not None else None
 
         if X_holdout is not None:
             Mamut._check_categorical(pd.Series(y_holdout))
@@ -408,6 +532,19 @@ class Mamut:
             )
             self.X_holdout_raw_ = X_holdout.copy()
             self.y_holdout_original_ = y_holdout_original
+            if groups_holdout is not None:
+                if len(groups_holdout) != len(X_holdout):
+                    raise ValueError(
+                        "groups_holdout must have the same length as X_holdout."
+                    )
+                self.groups_holdout_ = pd.Series(groups_holdout).copy()
+                self.groups_holdout_.index = X_holdout.index
+                overlap = set(groups_modeling).intersection(self.groups_holdout_)
+                if overlap:
+                    raise ValueError(
+                        "Explicit holdout groups overlap modeling groups; "
+                        "holdout evaluation would not be independent."
+                    )
         elif self.holdout_size is not None:
             (
                 X_modeling,
@@ -416,13 +553,14 @@ class Mamut:
                 y_holdout_encoded,
                 y_modeling_original,
                 self.y_holdout_original_,
-            ) = train_test_split(
+                groups_modeling,
+                self.groups_holdout_,
+            ) = self._split_data(
                 X_modeling,
                 y_modeling,
                 y_modeling_original,
+                groups_modeling,
                 test_size=self.holdout_size,
-                stratify=y_modeling,
-                random_state=self.random_state,
             )
         else:
             y_holdout_encoded = None
@@ -430,25 +568,35 @@ class Mamut:
         self.X_modeling_raw_ = X_modeling.copy()
         self.y_modeling_raw_ = y_modeling.copy()
         self.y_modeling_original_ = y_modeling_original.copy()
+        self.groups_modeling_ = (
+            groups_modeling.copy() if groups_modeling is not None else None
+        )
 
         (
             X_train_raw,
             X_validation_raw,
             y_train,
             y_validation,
-        ) = train_test_split(
+            _,
+            _,
+            self.groups_train_,
+            self.groups_validation_,
+        ) = self._split_data(
             X_modeling,
             y_modeling,
+            y_modeling_original,
+            groups_modeling,
             test_size=self.validation_size,
-            stratify=y_modeling,
-            random_state=self.random_state,
         )
 
         X_train = X_train_raw
         X_validation = X_validation_raw
         self.y_train_raw_ = y_train.copy()
         self.y_validation_raw_ = y_validation.copy()
-        if self.preprocess:
+        use_shared_preprocessor = self.preprocess and (
+            self.preprocessing_profile == "generic_ohe"
+        )
+        if use_shared_preprocessor:
             X_train, y_train = self.preprocessor.fit_transform(X_train, y_train)
             X_validation = self.preprocessor.transform(X_validation)
             if self.X_holdout_raw_ is not None:
@@ -480,11 +628,20 @@ class Mamut:
             self.y_train,
             self.X_validation,
             self.y_validation,
+            X_train_raw=self.X_train_raw_,
+            y_train_raw=self.y_train_raw_,
+            X_validation_raw=self.X_validation_raw_,
+            y_validation_raw=self.y_validation_raw_,
+            groups_train_raw=self.groups_train_,
+            preprocessor_factory=self._make_model_preprocessor,
             exclude_models=self.exclude_models,
+            include_models=self.include_models,
+            search_profile=self.search_profile,
             score_metric=self.score_metric,
             optimization_method=self.optimization_method,
             n_iterations=self.n_iterations,
             random_state=self.random_state,
+            n_jobs=self.n_jobs,
             verbose=self.verbose,
         )
 
@@ -493,15 +650,21 @@ class Mamut:
             _,
             score_for_best_model,
             fitted_models,
+            fitted_preprocessors,
+            fitted_training_data,
+            fitted_validation_data,
             validation_summary,
             studies,
         ) = self.model_selector.compare_models()
 
         self.raw_fitted_models_ = fitted_models
+        self.fitted_preprocessors_ = fitted_preprocessors
+        self.fitted_training_data_ = fitted_training_data
+        self.fitted_validation_data_ = fitted_validation_data
         self.optuna_studies_ = studies
         self.fitted_models_ = [
-            self._make_public_pipeline(model, self.preprocessor)
-            for model in fitted_models.values()
+            self._make_public_pipeline(model, self.fitted_preprocessors_[model_name])
+            for model_name, model in fitted_models.items()
         ]
 
         # Update the score metric based on binary/multiclass problem (for ensembles)
@@ -513,16 +676,76 @@ class Mamut:
             by=self.score_metric_name, ascending=False
         ).reset_index(drop=True)
         self.best_validation_score_ = score_for_best_model
-        self.best_score_ = score_for_best_model
         self.validation_selected_estimator_ = best_model
         self.selected_estimator_ = best_model
-        public_preprocessor = self.preprocessor
-        if self.refit_final_model:
-            self.final_preprocessor_, self.final_estimator_ = (
-                self._refit_selected_model(best_model)
+        self.selection_summary_ = self._build_selection_summary(
+            validation_summary, selected_model_name=best_model.__class__.__name__
+        )
+        if self.selection_strategy in {"nested_cv", "repeated_cv"}:
+            if self.selection_strategy == "repeated_cv":
+                warnings.warn(
+                    "selection_strategy='repeated_cv' is deprecated; use "
+                    "'nested_cv' for nested, fold-local model selection.",
+                    DeprecationWarning,
+                    stacklevel=2,
+                )
+            self.selection_summary_ = self.model_selector.nested_cv_selection_scores(
+                X=self.X_modeling_raw_,
+                y=self.y_modeling_raw_,
+                groups=self.groups_modeling_,
+                cv_splits=self.selection_cv_splits,
+                cv_repeats=self.selection_cv_repeats,
+                confidence_level=self.evidence_confidence_level,
             )
+            selection_decision = repeated_cv_selection_decision(
+                self.selection_summary_,
+                practical_margin=self.selection_practical_margin,
+            )
+            selected_model_name = selection_decision["model"]
+            self.selected_estimator_ = self.raw_fitted_models_[selected_model_name]
+            self.selection_summary_ = self._mark_selected_model(
+                self.selection_summary_,
+                selected_model_name=selected_model_name,
+                selection_strategy="nested_cv",
+                selection_decision_status=selection_decision["status"],
+            )
+            score_for_best_model = float(
+                self.selection_summary_.loc[
+                    self.selection_summary_["model"].eq(selected_model_name),
+                    "mean_score",
+                ].iloc[0]
+            )
+        self.best_score_ = score_for_best_model
+        selected_model_name = self.selected_estimator_.__class__.__name__
+        public_preprocessor = self.fitted_preprocessors_.get(selected_model_name)
+        self.preprocessor = public_preprocessor
+        self.X_train, self.y_train = self.fitted_training_data_[selected_model_name]
+        self.X_validation, self.y_validation = self.fitted_validation_data_[
+            selected_model_name
+        ]
+        if self.X_holdout_raw_ is not None:
+            self.X_holdout = self._transform_for_model(
+                selected_model_name, self.X_holdout_raw_
+            )
+        if self.refit_final_model:
+            if self.selection_strategy in {"nested_cv", "repeated_cv"}:
+                self.final_preprocessor_, self.final_estimator_ = (
+                    self._retune_selected_model_on_modeling_data(selected_model_name)
+                )
+            else:
+                self.final_preprocessor_, self.final_estimator_ = (
+                    self._refit_selected_model(self.selected_estimator_)
+                )
             self.selected_estimator_ = self.final_estimator_
             public_preprocessor = self.final_preprocessor_
+            self.preprocessor = public_preprocessor
+            if self.X_holdout_raw_ is not None:
+                if self.final_preprocessor_ is not None:
+                    self.X_holdout = self.final_preprocessor_.transform(
+                        self.X_holdout_raw_.copy()
+                    )
+                else:
+                    self.X_holdout = self._as_model_input(self.X_holdout_raw_)
 
         self.best_model_ = self._make_public_pipeline(
             self.selected_estimator_, public_preprocessor
@@ -531,14 +754,23 @@ class Mamut:
         self.training_summary_ = validation_summary
         self.holdout_summary_ = (
             self._score_models_on_dataset(
-                self.raw_fitted_models_, self.X_holdout, self.y_holdout
+                self.raw_fitted_models_, self.X_holdout_raw_, self.y_holdout
             )
-            if self.X_holdout is not None
+            if self.X_holdout_raw_ is not None
             else None
         )
+        if self.holdout_summary_ is not None and self.refit_final_model:
+            final_scores = self._score_model_with_metrics(
+                self.selected_estimator_,
+                self.X_holdout,
+                self.y_holdout,
+            )
+            selected_row = self.holdout_summary_["model"].eq(selected_model_name)
+            for metric_name, score in final_scores.items():
+                self.holdout_summary_.loc[selected_row, metric_name] = score
         self.holdout_score_ = (
             self._score_selected_model_on_holdout()
-            if self.X_holdout is not None
+            if self.X_holdout_raw_ is not None
             else None
         )
 
@@ -548,6 +780,38 @@ class Mamut:
             self._save_fitted_models()
 
         return self.best_model_
+
+    def _build_selection_summary(
+        self, validation_summary: pd.DataFrame, *, selected_model_name: str
+    ) -> pd.DataFrame:
+        summary = validation_summary.copy()
+        summary["metric"] = self.score_metric_name
+        summary["mean_score"] = summary[self.score_metric_name]
+        summary["std_score"] = np.nan
+        summary["ci_low"] = np.nan
+        summary["ci_high"] = np.nan
+        summary["n_scores"] = 1
+        summary["selection_duration"] = summary["duration"]
+        summary["status"] = "ok"
+        return self._mark_selected_model(
+            summary,
+            selected_model_name=selected_model_name,
+            selection_strategy="single_split",
+        )
+
+    @staticmethod
+    def _mark_selected_model(
+        summary: pd.DataFrame,
+        *,
+        selected_model_name: str,
+        selection_strategy: str,
+        selection_decision_status: str = "confirmed",
+    ) -> pd.DataFrame:
+        summary = summary.copy()
+        summary["selected"] = summary["model"].eq(selected_model_name)
+        summary["selection_strategy"] = selection_strategy
+        summary["selection_decision_status"] = selection_decision_status
+        return summary
 
     def _save_fitted_models(self) -> None:
         models_dir = os.path.join(
@@ -578,9 +842,8 @@ class Mamut:
         return estimator.__class__.__name__
 
     def _refit_selected_model(self, selected_estimator):
-        preprocessor = (
-            Preprocessor(**self.preprocessor_kwargs) if self.preprocess else None
-        )
+        selected_model_name = selected_estimator.__class__.__name__
+        preprocessor = self._make_model_preprocessor(selected_model_name)
         if preprocessor is not None:
             X_final, y_final = preprocessor.fit_transform(
                 self.X_modeling_raw_.copy(),
@@ -591,8 +854,136 @@ class Mamut:
             y_final = np.asarray(self.y_modeling_raw_)
 
         final_estimator = clone(selected_estimator)
-        final_estimator.fit(X_final, y_final)
+        fit_estimator(final_estimator, X_final, y_final)
         return preprocessor, final_estimator
+
+    def _retune_selected_model_on_modeling_data(self, selected_model_name: str):
+        final_selector = ModelSelector(
+            self._as_model_input(self.X_modeling_raw_),
+            np.asarray(self.y_modeling_raw_),
+            self._as_model_input(self.X_validation_raw_),
+            np.asarray(self.y_validation_raw_),
+            score_metric=self.model_selector.base_score_metric,
+            X_train_raw=self.X_modeling_raw_,
+            y_train_raw=self.y_modeling_raw_,
+            X_validation_raw=self.X_validation_raw_,
+            y_validation_raw=self.y_validation_raw_,
+            groups_train_raw=self.groups_modeling_,
+            preprocessor_factory=self._make_model_preprocessor,
+            include_models=[selected_model_name],
+            search_profile=self.search_profile,
+            optimization_method=self.optimization_method,
+            n_iterations=self.n_iterations,
+            random_state=self.random_state,
+            n_jobs=self.n_jobs,
+            verbose=self.verbose,
+        )
+        estimator, preprocessor, _, _, study = final_selector.tune_and_fit_model(
+            selected_model_name
+        )
+        self.optuna_studies_[selected_model_name] = study
+        return preprocessor, estimator
+
+    def _make_candidate_pipeline(self, model_name: str, estimator):
+        preprocessor = self._make_model_preprocessor(model_name)
+        profile = preprocessor.profile if preprocessor is not None else "generic_ohe"
+        return CandidatePipelineClassifier(
+            estimator=clone(estimator),
+            preprocess=preprocessor is not None,
+            profile=profile,
+            preprocessor_kwargs=self.preprocessor_kwargs.copy(),
+        )
+
+    def _ensemble_estimators(self, model_names=None):
+        names = model_names or list(self.raw_fitted_models_)
+        return [
+            (name, self._make_candidate_pipeline(name, self.raw_fitted_models_[name]))
+            for name in names
+        ]
+
+    def _fitted_candidate_pipelines(self) -> dict:
+        pipelines = {}
+        selected_name = (
+            self.selected_estimator_.__class__.__name__
+            if self.selected_estimator_ is not None
+            else None
+        )
+        for model_name, estimator in self.raw_fitted_models_.items():
+            if self.refit_final_model and model_name == selected_name:
+                estimator = self.selected_estimator_
+                preprocessor = self.final_preprocessor_
+            else:
+                preprocessor = self.fitted_preprocessors_.get(model_name)
+            pipeline = self._make_candidate_pipeline(model_name, estimator)
+            pipeline.estimator_ = estimator
+            pipeline.preprocessor_ = preprocessor
+            pipeline.classes_ = estimator.classes_
+            pipelines[model_name] = pipeline
+        return pipelines
+
+    def _split_data(self, X, y, y_original, groups, *, test_size: float):
+        if groups is None:
+            X_train, X_eval, y_train, y_eval, y_original_train, y_original_eval = (
+                train_test_split(
+                    X,
+                    y,
+                    y_original,
+                    test_size=test_size,
+                    stratify=y,
+                    random_state=self.random_state,
+                )
+            )
+            return (
+                X_train,
+                X_eval,
+                y_train,
+                y_eval,
+                y_original_train,
+                y_original_eval,
+                None,
+                None,
+            )
+
+        target_distribution = pd.Series(y).value_counts(normalize=True)
+        splitter = GroupShuffleSplit(
+            n_splits=32,
+            test_size=test_size,
+            random_state=self.random_state,
+        )
+        candidates = []
+        for train_idx, eval_idx in splitter.split(X, y, groups):
+            y_train = y.iloc[train_idx]
+            y_eval = y.iloc[eval_idx]
+            if any(
+                (
+                    y_train.nunique() < target_distribution.size,
+                    y_eval.nunique() < target_distribution.size,
+                )
+            ):
+                continue
+            eval_distribution = y_eval.value_counts(normalize=True).reindex(
+                target_distribution.index, fill_value=0.0
+            )
+            balance_error = float((eval_distribution - target_distribution).abs().sum())
+            size_error = abs((len(eval_idx) / len(X)) - test_size)
+            candidates.append((balance_error + size_error, train_idx, eval_idx))
+
+        if not candidates:
+            raise ValueError(
+                "Unable to construct a group-disjoint split containing every "
+                "target class in both partitions."
+            )
+        _, train_idx, eval_idx = min(candidates, key=lambda candidate: candidate[0])
+        return (
+            X.iloc[train_idx],
+            X.iloc[eval_idx],
+            y.iloc[train_idx],
+            y.iloc[eval_idx],
+            y_original.iloc[train_idx],
+            y_original.iloc[eval_idx],
+            groups.iloc[train_idx],
+            groups.iloc[eval_idx],
+        )
 
     def _score_selected_model_on_holdout(self) -> float:
         if self.refit_final_model:
@@ -605,7 +996,11 @@ class Mamut:
             )
 
         return self._score_model_on_dataset(
-            self.selected_estimator_, self.X_holdout, self.y_holdout
+            self.selected_estimator_,
+            self._transform_for_model(
+                self.selected_estimator_.__class__.__name__, self.X_holdout_raw_
+            ),
+            self.y_holdout,
         )
 
     @staticmethod
@@ -632,15 +1027,28 @@ class Mamut:
         rows = []
         for model_name in model_order:
             model = models[model_name]
+            X_model = self._transform_for_model(model_name, X)
             rows.append(
                 {
                     "model": model_name,
-                    **self._score_model_with_metrics(model, X, y),
+                    **self._score_model_with_metrics(model, X_model, y),
                     "duration": duration_by_model.get(model_name, np.nan),
                 }
             )
 
         return pd.DataFrame(rows)
+
+    def _transform_for_model(self, model_name: str, X: pd.DataFrame):
+        if X is None:
+            return None
+        preprocessor = (
+            self.fitted_preprocessors_.get(model_name)
+            if isinstance(self.fitted_preprocessors_, dict)
+            else None
+        )
+        if preprocessor is None:
+            return self._as_model_input(X)
+        return preprocessor.transform(X.copy())
 
     def _score_model_with_metrics(self, fitted_model, X, y) -> dict:
         y = np.asarray(y)
@@ -743,7 +1151,7 @@ class Mamut:
             raise ValueError(
                 "n_top_models must be an integer greater than or equal to 1."
             )
-        X_evaluation, y_evaluation, evaluation_summary, evaluation_dataset = (
+        _, y_evaluation, evaluation_summary, evaluation_dataset = (
             self._get_evaluation_dataset(dataset)
         )
         evidence_report = (
@@ -753,11 +1161,16 @@ class Mamut:
         )
 
         evaluator = ModelEvaluator(
-            self.raw_fitted_models_,
-            X_evaluation=X_evaluation,
+            self._fitted_candidate_pipelines(),
+            X_evaluation=(
+                self.X_holdout_raw_
+                if evaluation_dataset == "holdout"
+                else self.X_validation_raw_
+            ),
             y_evaluation=y_evaluation,
             X_train=self.X_train,
             y_train=self.y_train,
+            X_explanation=self.X_train_raw_,
             X=self.X,
             y=self.y,
             optimizer=self.optimization_method,
@@ -799,7 +1212,18 @@ class Mamut:
     def generate_evidence(
         self,
         dataset: Literal["auto", "validation", "holdout"] = "auto",
+        include_candidate_comparison: bool = True,
     ) -> dict:
+        """Build diagnostic evidence without changing the fitted candidate.
+
+        Parameters
+        ----------
+        dataset : Literal["auto", "validation", "holdout"]
+            Evaluation partition to summarize.
+        include_candidate_comparison : bool
+            Whether to score non-selected MAMUT candidates alongside fixed
+            baselines. Disable this for a locked final confirmation analysis.
+        """
         self._check_fitted()
         _, _, _, evaluation_dataset = self._get_evaluation_dataset(dataset)
 
@@ -809,21 +1233,37 @@ class Mamut:
         else:
             X_evaluation_raw = self.X_validation_raw_
             y_evaluation_raw = self.y_validation_raw_
+        if evaluation_dataset == "holdout":
+            X_evidence_train = self.X_modeling_raw_
+            y_evidence_train = self.y_modeling_raw_
+            groups_evidence_train = self.groups_modeling_
+            groups_evaluation = self.groups_holdout_
+        else:
+            X_evidence_train = self.X_train_raw_
+            y_evidence_train = self.y_train_raw_
+            groups_evidence_train = self.groups_train_
+            groups_evaluation = self.groups_validation_
 
         self.evidence_report_ = build_evidence_report(
             X=self.X_modeling_raw_,
             y=self.y_modeling_raw_,
             y_leakage=self.y_modeling_original_,
-            X_train=self.X_train_raw_,
-            y_train=self.y_train_raw_,
+            X_train=X_evidence_train,
+            y_train=y_evidence_train,
             X_evaluation=X_evaluation_raw,
             y_evaluation=y_evaluation_raw,
             selected_estimator=self.selected_estimator_,
+            candidate_estimators=(
+                self.raw_fitted_models_ if include_candidate_comparison else None
+            ),
             metric_name=self.score_metric_name,
             binary=self.binary,
-            preprocessor_factory=self._make_evidence_preprocessor,
+            preprocessor_factory=self._make_model_preprocessor,
             evaluation_dataset=evaluation_dataset,
             holdout_available=self.X_holdout is not None,
+            groups=self.groups_modeling_,
+            groups_train=groups_evidence_train,
+            groups_evaluation=groups_evaluation,
             cv_splits=self.evidence_cv_splits,
             cv_repeats=self.evidence_cv_repeats,
             confidence_level=self.evidence_confidence_level,
@@ -837,10 +1277,49 @@ class Mamut:
         self.selection_guidance_ = self.evidence_report_["selection_guidance"]
         return self.evidence_report_
 
-    def _make_evidence_preprocessor(self):
+    def _make_model_preprocessor(self, model_name: Optional[str] = None):
         if not self.preprocess:
             return None
-        return Preprocessor(**self.preprocessor_kwargs)
+        profile = self._preprocessing_profile_for_label(model_name)
+        kwargs = self.preprocessor_kwargs.copy()
+        if profile == "native_categorical" and (
+            kwargs.get("pca") or kwargs.get("feature_selection")
+        ):
+            profile = "tree_ohe"
+        if all(
+            [
+                profile == "native_categorical",
+                self.imbalanced_,
+                kwargs.get("imbalanced_resampling", True),
+            ]
+        ):
+            profile = "tree_ohe"
+        kwargs["profile"] = profile
+        return Preprocessor(**kwargs)
+
+    def _preprocessing_profile_for_label(self, model_name: Optional[str]) -> str:
+        if self.preprocessing_profile == "generic_ohe" or model_name is None:
+            return "generic_ohe"
+
+        normalized_name = self._normalize_model_label(model_name)
+        if normalized_name in set(available_model_names()):
+            return preprocessing_profile_for_model(normalized_name)
+        return "generic_ohe"
+
+    @staticmethod
+    def _normalize_model_label(model_name: str) -> str:
+        for prefix in ("MAMUT Candidate (", "MAMUT Selected ("):
+            if model_name.startswith(prefix) and model_name.endswith(")"):
+                return model_name[len(prefix) : -1]
+        baseline_aliases = {
+            "Logistic Regression": "LogisticRegression",
+            "Random Forest": "RandomForestClassifier",
+            "Dummy Most Frequent": "DummyClassifier",
+        }
+        return baseline_aliases.get(model_name, model_name)
+
+    def _make_evidence_preprocessor(self, model_name: Optional[str] = None):
+        return self._make_model_preprocessor(model_name)
 
     def _get_evaluation_dataset(self, dataset: str):
         if dataset not in {"auto", "validation", "holdout"}:
@@ -858,7 +1337,7 @@ class Mamut:
             if self.holdout_summary_ is None:
                 self.holdout_summary_ = self._score_models_on_dataset(
                     self.raw_fitted_models_,
-                    self.X_holdout,
+                    self.X_holdout_raw_,
                     self.y_holdout,
                 )
             return (
@@ -908,20 +1387,14 @@ class Mamut:
         self._check_fitted()
 
         ensemble = VotingClassifier(
-            estimators=[
-                (
-                    model_name,
-                    clone(model),
-                )
-                for model_name, model in self.raw_fitted_models_.items()
-            ],
+            estimators=self._ensemble_estimators(),
             voting=voting,
         )
-        ensemble.fit(self.X_train, self.y_train)
-        y_pred = ensemble.predict(self.X_validation)
-        score = self.score_metric(self.y_validation, y_pred)
+        ensemble.fit(self.X_train_raw_, self.y_train_raw_)
+        y_pred = ensemble.predict(self.X_validation_raw_)
+        score = self.score_metric(self.y_validation_raw_, y_pred)
 
-        self.ensemble_ = self._make_public_pipeline(ensemble, self.preprocessor)
+        self.ensemble_ = self._make_public_pipeline(ensemble, None)
         log.info(
             f"Created ensemble with all models and voting='{voting}'. "
             f"Ensemble score on validation set: {score:.4f} {self.score_metric.__name__}"
@@ -948,162 +1421,60 @@ class Mamut:
             The greedy ensemble model pipeline.
         """
         self._check_fitted()
+        n_models = min(n_models, len(self.raw_fitted_models_))
+        if n_models < 2:
+            raise ValueError(
+                "At least two fitted models are required to build an ensemble."
+            )
+        ranked_names = (
+            self.validation_summary_.sort_values(
+                self.score_metric_name, ascending=False
+            )["model"]
+            .head(n_models)
+            .tolist()
+        )
+        selected_names = [ranked_names[0]]
+        best_ensemble = None
+        best_score = -np.inf
 
-        # Initialize the ensemble with the best model
-        ensemble_models = [self.validation_selected_estimator_]
-        ensemble_scores = [self.best_score_]
-
-        for _ in range(n_models - 1):
-            best_score = -np.inf
-            best_model = None
-
-            for model in self.raw_fitted_models_.values():
-                candidate_ensemble = ensemble_models + [model]
-                candidate_voting_clf = VotingClassifier(
-                    estimators=[
-                        (f"model_{i}", clone(m))
-                        for i, m in enumerate(candidate_ensemble)
-                    ],
+        while len(selected_names) < n_models:
+            round_best_name = None
+            round_best_ensemble = None
+            round_best_score = -np.inf
+            for candidate_name in sorted(set(ranked_names).difference(selected_names)):
+                candidate_names = [*selected_names, candidate_name]
+                candidate_ensemble = VotingClassifier(
+                    estimators=self._ensemble_estimators(candidate_names),
                     voting=voting,
                 )
-                candidate_voting_clf.fit(self.X_train, self.y_train)
+                candidate_ensemble.fit(self.X_train_raw_, self.y_train_raw_)
                 score = self.score_metric(
-                    self.y_validation,
-                    candidate_voting_clf.predict(self.X_validation),
+                    self.y_validation_raw_,
+                    candidate_ensemble.predict(self.X_validation_raw_),
                 )
+                if score > round_best_score:
+                    round_best_name = candidate_name
+                    round_best_ensemble = candidate_ensemble
+                    round_best_score = score
+            selected_names.append(round_best_name)
+            best_ensemble = round_best_ensemble
+            best_score = round_best_score
 
-                if score > best_score:
-                    best_score = score
-                    best_model = model
-
-            ensemble_models.append(best_model)
-            ensemble_scores.append(best_score)
-
-        ensemble = VotingClassifier(
-            estimators=[
-                (f"model_{i}", clone(m)) for i, m in enumerate(ensemble_models)
-            ],
-            voting=voting,
-        )
-        ensemble.fit(self.X_train, self.y_train)
-        y_pred = ensemble.predict(self.X_validation)
-        score = self.score_metric(self.y_validation, y_pred)
-
-        self.ensemble_models_ = ensemble_models
-        self.greedy_ensemble_ = self._make_public_pipeline(ensemble, self.preprocessor)
+        self.ensemble_models_ = selected_names
+        self.greedy_ensemble_ = self._make_public_pipeline(best_ensemble, None)
 
         log.info(
             f"Created greedy ensemble with voting='{voting}' \n"
-            f"and {n_models} models: {[m.__class__.__name__ for m in ensemble_models]} \n"
-            f"Ensemble score on validation set: {score:.4f} {self.score_metric.__name__}"
+            f"and {n_models} models: {selected_names} \n"
+            f"Ensemble score on validation set: {best_score:.4f} {self.score_metric.__name__}"
         )
 
         return self.greedy_ensemble_
 
     def create_greedy_ensemble(self, max_models=6):
-        self._check_fitted()
-        models = [model for name, model in self.raw_fitted_models_.items()]
-
-        if max_models > len(models):
-            max_models = len(models)
-            log.info(
-                f"Max models set to {max_models} as there are only {len(models)} models available"
-                f"in the bag-of-models used in this experiment."
-            )
-
-        if len(models) < 2:
-            raise ValueError(
-                "At least two fitted models are required to build an ensemble."
-            )
-
-        # Sort models list by their performance on the validation set.
-        sorted_models = sorted(
-            models,
-            key=lambda model: self._score_model_on_validation(model),
-            reverse=True,
-        )
-
-        # Start with the best and second best model
-        ensemble_models = [sorted_models[0], sorted_models[1]]
-        remaining_models = {
-            model.__class__.__name__: model for model in copy(sorted_models[2:])
-        }
-        best_score = self._score_model_on_validation(
-            self._create_stacking_classifier(ensemble_models).fit(
-                self.X_train, self.y_train
-            )
-        )
-        ensemble_scores = [best_score]
-
-        # Greedily add models to the ensemble
-        for _ in range(max_models - 2):
-            best_score = -np.inf
-            best_model = None
-
-            for model in remaining_models.values():
-                candidate_ensemble = ensemble_models + [model]
-                candidate_stacking_clf = self._create_stacking_classifier(
-                    candidate_ensemble
-                )
-                candidate_stacking_clf.fit(self.X_train, self.y_train)
-                score = self._score_model_on_validation(candidate_stacking_clf)
-
-                if score > best_score:
-                    best_score = score
-                    best_model = model
-
-            ensemble_models.append(best_model)
-            ensemble_scores.append(best_score)
-            # Remove this best model from the remaining models dict
-            del remaining_models[best_model.__class__.__name__]
-
-        # From nested family of ensembles pick the best one based on ensemble_scores
-        best_score = max(ensemble_scores)
-        # Check from the end of the list to find the best ensemble
-        for i in range(len(ensemble_scores) - 1, 0, -1):
-            if ensemble_scores[i] == best_score:
-                ensemble_models = ensemble_models[: i + 2]
-                break
-
-        # Create the final stacking classifier
-        final_stacking_clf = self._create_stacking_classifier(ensemble_models)
-        final_stacking_clf.fit(self.X_train, self.y_train)
-        self.greedy_ensemble_ = final_stacking_clf
-
-        log.info(
-            f"Created greedy ensemble with {len(ensemble_models)} models. Best score: {best_score:.4f}."
-            f"For details on the ensemble please run evaluate() method and see the report."
-        )
-
-        # Create a pipeline with the best ensemble
-        self.greedy_ensemble_ = self._make_public_pipeline(
-            final_stacking_clf, self.preprocessor
-        )
-
-        return self.greedy_ensemble_
-
-    def _score_model_on_validation(self, model):
-        if self.roc:
-            if self.binary:
-                score_on_validation = self.score_metric(
-                    self.y_validation,
-                    model.predict_proba(self.X_validation)[:, 1],
-                )
-            else:
-                score_on_validation = self.score_metric(
-                    self.y_validation,
-                    model.predict_proba(self.X_validation),
-                )
-        else:
-            score_on_validation = self.score_metric(
-                self.y_validation, model.predict(self.X_validation)
-            )
-        return score_on_validation
-
-    def _create_stacking_classifier(self, models):
-        estimators = [(model.__class__.__name__, clone(model)) for model in models]
-        return StackingClassifier(
-            estimators=estimators, final_estimator=RandomForestClassifier()
+        return self._create_greedy_ensemble_voting(
+            n_models=max_models,
+            voting="soft",
         )
 
     def _predict(self, X: pd.DataFrame, proba: bool = False):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,8 @@ dependencies = [
     "Jinja2>=3.0.2,<4.0.0",
     "psutil>=6.1.1,<7.0.0",
     "shap>=0.46.0,<0.47.0",
+    "lightgbm>=4.6.0,<5.0.0",
+    "catboost>=1.2.10,<2.0.0",
 ]
 
 [project.urls]
@@ -101,3 +103,8 @@ extend_exclude = ["debug", "docs"]
 ignore_notebooks = true
 known_first_party = ["mamut"]
 package_module_name_map = { "imbalanced-learn" = "imblearn", "scikit-learn" = "sklearn" }
+
+[tool.pytest.ini_options]
+filterwarnings = [
+    "ignore:Conversion of an array with ndim > 0 to a scalar is deprecated.*:DeprecationWarning:numpy\\.ma\\.extras",
+]

--- a/scripts/benchmark_evidence.py
+++ b/scripts/benchmark_evidence.py
@@ -21,8 +21,6 @@ DATASET_LOADERS: dict[str, DatasetLoader] = {
     "digits": load_digits,
 }
 
-DEFAULT_EXCLUDED_MODELS = ("SVC", "MLPClassifier", "XGBClassifier")
-
 
 def run_benchmark(
     dataset_names: Iterable[str],
@@ -61,12 +59,13 @@ def _run_dataset(
 ) -> dict:
     X, y = _load_dataset(dataset_name)
     mamut = Mamut(
-        exclude_models=list(DEFAULT_EXCLUDED_MODELS),
+        search_profile="quick",
         score_metric="balanced_accuracy",
         optimization_method="random_search",
         n_iterations=n_iterations,
         random_state=random_state,
         holdout_size=holdout_size,
+        refit_final_model=True,
         evidence_cv_splits=evidence_cv_splits,
         evidence_cv_repeats=evidence_cv_repeats,
         num_imputation="mean",
@@ -119,7 +118,7 @@ def _best_baseline_row(
     baseline_comparison: pd.DataFrame, *, selected_model_label: str
 ) -> pd.Series:
     baselines = baseline_comparison.loc[
-        baseline_comparison["model"] != selected_model_label
+        ~baseline_comparison["model"].str.startswith("MAMUT ")
     ].dropna(subset=["score"])
     if baselines.empty:
         return pd.Series({"model": "", "score": np.nan})

--- a/scripts/benchmark_kaggle.py
+++ b/scripts/benchmark_kaggle.py
@@ -17,6 +17,7 @@ from typing import Iterable, Literal, Sequence
 
 import numpy as np
 import pandas as pd
+from sklearn.base import clone
 from sklearn.model_selection import StratifiedGroupKFold, train_test_split
 
 import mamut
@@ -792,7 +793,7 @@ def run_confirmation_benchmark(
     confirmation_groups: pd.Series | None,
     *,
     config: BenchmarkConfig,
-) -> tuple[pd.DataFrame, dict, list[dict]]:
+) -> tuple[pd.DataFrame, dict, list[dict], Mamut]:
     validate_recipe_scope(config.recipe, config.group_scope)
     X_development, y_development, X_confirmation, y_confirmation = (
         prepare_spaceship_modeling_split(
@@ -899,7 +900,7 @@ def run_confirmation_benchmark(
         file=sys.stderr,
         flush=True,
     )
-    return run_results, aggregate, diagnostics
+    return run_results, aggregate, diagnostics, model
 
 
 def fit_submission_model(
@@ -907,10 +908,28 @@ def fit_submission_model(
     test: pd.DataFrame,
     *,
     config: BenchmarkConfig,
+    frozen_model: Mamut | None = None,
 ) -> tuple[pd.DataFrame, Mamut]:
     X, y, X_test, passenger_ids = prepare_spaceship_features(
         train, test, recipe=config.recipe
     )
+    if frozen_model is not None:
+        selected_model = frozen_model.selected_estimator_.__class__.__name__
+        estimator = clone(frozen_model.selected_estimator_)
+        preprocessor = frozen_model._make_model_preprocessor(selected_model)
+        if preprocessor is not None:
+            X_fitted, y_fitted = preprocessor.fit_transform(X.copy(), y.copy())
+            X_predict = preprocessor.transform(X_test.copy())
+        else:
+            X_fitted, y_fitted = X, y
+            X_predict = X_test
+        estimator.fit(X_fitted, y_fitted)
+        predictions = _coerce_bool_predictions(estimator.predict(X_predict))
+        submission = pd.DataFrame(
+            {"PassengerId": passenger_ids, "Transported": predictions}
+        )
+        return submission, frozen_model
+
     model = _make_mamut(config, random_state=config.random_state, final_refit=True)
     groups = (
         validation_groups(train, config.group_scope)
@@ -923,6 +942,12 @@ def fit_submission_model(
         {"PassengerId": passenger_ids, "Transported": predictions}
     )
     return submission, model
+
+
+def selected_hyperparameters(model: Mamut) -> dict:
+    selected_model = model.selected_estimator_.__class__.__name__
+    study = model.optuna_studies_.get(selected_model)
+    return dict(study.best_params) if study is not None else {}
 
 
 def write_submission(submission: pd.DataFrame, path: Path) -> Path:
@@ -1173,6 +1198,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         "confirmation_reserved": args.stage != "diagnostic",
         "official_train_test_relational_overlap": relational_overlap_audit(train, test),
     }
+    confirmation_model = None
     if args.stage == "diagnostic":
         run_results, aggregate, diagnostics = run_spaceship_benchmark(
             train, test, config=config
@@ -1200,7 +1226,12 @@ def main(argv: Sequence[str] | None = None) -> int:
                 development, test, config=config
             )
         else:
-            run_results, aggregate, diagnostics = run_confirmation_benchmark(
+            (
+                run_results,
+                aggregate,
+                diagnostics,
+                confirmation_model,
+            ) = run_confirmation_benchmark(
                 development,
                 confirmation,
                 development_groups,
@@ -1254,13 +1285,20 @@ def main(argv: Sequence[str] | None = None) -> int:
         )
 
     if args.write_submission:
-        submission, _ = fit_submission_model(train, test, config=config)
+        submission, submission_model = fit_submission_model(
+            train,
+            test,
+            config=config,
+            frozen_model=confirmation_model,
+        )
         submission_path = output_dir / "submission.csv"
         write_submission(submission, submission_path)
         payload["submission"] = {
             "generated": True,
             "uploaded": False,
             "path": str(submission_path),
+            "fit_policy": "fixed_confirmation_parameters_refit_on_full_training",
+            "selected_hyperparameters": selected_hyperparameters(submission_model),
         }
         write_campaign_artifacts(payload, results_path, manifest_path)
         if args.submit:
@@ -1273,6 +1311,8 @@ def main(argv: Sequence[str] | None = None) -> int:
                 "uploaded": True,
                 "path": str(submission_path),
                 "message": message,
+                "fit_policy": "fixed_confirmation_parameters_refit_on_full_training",
+                "selected_hyperparameters": selected_hyperparameters(submission_model),
             }
             write_campaign_artifacts(payload, results_path, manifest_path)
     print(format_results(payload, args.format))

--- a/scripts/benchmark_kaggle.py
+++ b/scripts/benchmark_kaggle.py
@@ -1,0 +1,1353 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import platform
+import subprocess
+import time
+import warnings
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Iterable, Literal, Sequence
+
+import numpy as np
+import pandas as pd
+from sklearn.model_selection import StratifiedGroupKFold, train_test_split
+
+import mamut
+from mamut import Mamut
+from mamut.evidence import (
+    default_baseline_estimators,
+    detect_leakage_risks,
+    evaluate_estimators_on_split,
+)
+
+CompetitionName = Literal["spaceship-titanic"]
+RecipeName = Literal[
+    "raw",
+    "spaceship_inductive",
+    "spaceship_cohort",
+    "spaceship_basic",
+    "spaceship_inductive_v2",
+    "spaceship_cohort_v2",
+]
+ValidationProtocol = Literal["grouped", "row"]
+GroupScope = Literal["passenger", "household_component"]
+BenchmarkStage = Literal["diagnostic", "development", "confirmation"]
+OutputFormat = Literal["markdown", "json", "csv"]
+
+DEFAULT_CACHE_DIR = Path(".cache/mamut/kaggle")
+DEFAULT_OUTPUT_DIR = Path(".cache/mamut/benchmark-results")
+SPACESHIP_FILES = ("train.csv", "test.csv", "sample_submission.csv")
+RAW_DROP_COLUMNS = ("Transported",)
+SPACESHIP_BASIC_DROP_COLUMNS = (
+    "Transported",
+    "PassengerId",
+    "Name",
+    "Cabin",
+    "PassengerGroup",
+)
+DEFAULT_EXCLUDED_MODELS = ()
+DEFAULT_CONFIRMATION_SEED = 20260524
+FEATURE_RECIPE_VERSION = "2"
+
+warnings.filterwarnings(
+    "ignore",
+    message="Found unknown categories in columns .* during transform.*",
+    module="sklearn\\.preprocessing\\._encoders",
+)
+warnings.filterwarnings(
+    "ignore",
+    message="l1_ratio parameter is only used when penalty is 'elasticnet'.*",
+    module="sklearn\\.linear_model\\._logistic",
+)
+
+
+@dataclass(frozen=True)
+class BenchmarkConfig:
+    competition: CompetitionName
+    recipe: RecipeName
+    runs: int
+    n_iterations: int
+    random_state: int
+    holdout_size: float
+    validation_protocol: ValidationProtocol
+    score_metric: str
+    search_profile: str
+    selection_strategy: str
+    selection_cv_splits: int
+    selection_cv_repeats: int
+    selection_practical_margin: float
+    preprocessing_profile: str
+    optimization_method: str
+    excluded_models: tuple[str, ...]
+    included_models: tuple[str, ...] | None = None
+    group_scope: GroupScope = "passenger"
+    stage: BenchmarkStage = "diagnostic"
+    confirmation_size: float = 0.2
+    confirmation_seed: int = DEFAULT_CONFIRMATION_SEED
+
+
+@dataclass(frozen=True)
+class BenchmarkMetadata:
+    generated_at_utc: str
+    mamut_version: str
+    git_commit: str
+    train_sha256: str
+    test_sha256: str
+    sample_submission_sha256: str
+    git_branch: str
+    git_dirty: bool
+    python_version: str
+    feature_recipe_version: str
+
+
+def ensure_competition_data(
+    competition: CompetitionName,
+    cache_dir: Path = DEFAULT_CACHE_DIR,
+    *,
+    force_download: bool = False,
+) -> Path:
+    if competition != "spaceship-titanic":
+        raise ValueError("Only spaceship-titanic is supported in benchmark v1.")
+
+    data_dir = cache_dir / competition
+    data_dir.mkdir(parents=True, exist_ok=True)
+
+    missing_files = [
+        file_name
+        for file_name in SPACESHIP_FILES
+        if not (data_dir / file_name).exists()
+    ]
+    if missing_files or force_download:
+        for file_name in SPACESHIP_FILES:
+            command = [
+                "kaggle",
+                "competitions",
+                "download",
+                "-c",
+                competition,
+                "-f",
+                file_name,
+                "-p",
+                str(data_dir),
+                "-q",
+            ]
+            if force_download:
+                command.append("--force")
+            subprocess.run(command, check=True)
+
+    missing_after_download = [
+        file_name
+        for file_name in SPACESHIP_FILES
+        if not (data_dir / file_name).exists()
+    ]
+    if missing_after_download:
+        raise FileNotFoundError(
+            "Missing Kaggle competition files after download: "
+            f"{missing_after_download}. Check Kaggle CLI authentication."
+        )
+
+    return data_dir
+
+
+def load_spaceship_titanic(
+    data_dir: Path,
+) -> tuple[pd.DataFrame, pd.DataFrame, pd.DataFrame]:
+    train = pd.read_csv(data_dir / "train.csv")
+    test = pd.read_csv(data_dir / "test.csv")
+    sample_submission = pd.read_csv(data_dir / "sample_submission.csv")
+
+    required_train_columns = {"PassengerId", "Transported"}
+    required_test_columns = {"PassengerId"}
+    required_submission_columns = ["PassengerId", "Transported"]
+    if not required_train_columns.issubset(train.columns):
+        raise ValueError(f"train.csv must contain {sorted(required_train_columns)}.")
+    if not required_test_columns.issubset(test.columns):
+        raise ValueError(f"test.csv must contain {sorted(required_test_columns)}.")
+    if list(sample_submission.columns) != required_submission_columns:
+        raise ValueError(
+            "sample_submission.csv must have columns: "
+            f"{required_submission_columns}."
+        )
+
+    return train, test, sample_submission
+
+
+def prepare_spaceship_features(
+    train: pd.DataFrame,
+    test: pd.DataFrame,
+    *,
+    recipe: RecipeName,
+) -> tuple[pd.DataFrame, pd.Series, pd.DataFrame, pd.Series]:
+    y = train["Transported"].astype(bool).reset_index(drop=True)
+    passenger_ids = test["PassengerId"].copy().reset_index(drop=True)
+
+    if recipe == "raw":
+        X = train.drop(columns=list(RAW_DROP_COLUMNS)).reset_index(drop=True)
+        X_test = test[X.columns].copy().reset_index(drop=True)
+        return X, y, X_test, passenger_ids
+
+    if recipe in {
+        "spaceship_inductive",
+        "spaceship_cohort",
+        "spaceship_basic",
+        "spaceship_inductive_v2",
+        "spaceship_cohort_v2",
+    }:
+        X = _spaceship_features_for_recipe(train, recipe).reset_index(drop=True)
+        X_test = _spaceship_features_for_recipe(test, recipe).reset_index(drop=True)
+        X_test = X_test.reindex(columns=X.columns)
+        return X, y, X_test, passenger_ids
+
+    raise ValueError(
+        "recipe must be one of: raw, spaceship_inductive, spaceship_cohort, "
+        "spaceship_basic, spaceship_inductive_v2, spaceship_cohort_v2."
+    )
+
+
+def prepare_spaceship_modeling_split(
+    modeling: pd.DataFrame,
+    holdout: pd.DataFrame,
+    *,
+    recipe: RecipeName,
+) -> tuple[pd.DataFrame, pd.Series, pd.DataFrame, pd.Series]:
+    y_modeling = modeling["Transported"].astype(bool).reset_index(drop=True)
+    y_holdout = holdout["Transported"].astype(bool).reset_index(drop=True)
+    X_modeling = _spaceship_features_for_recipe(modeling, recipe).reset_index(drop=True)
+    X_holdout = _spaceship_features_for_recipe(holdout, recipe).reset_index(drop=True)
+    X_holdout = X_holdout.reindex(columns=X_modeling.columns)
+    return X_modeling, y_modeling, X_holdout, y_holdout
+
+
+def _spaceship_features_for_recipe(
+    frame: pd.DataFrame, recipe: RecipeName
+) -> pd.DataFrame:
+    if recipe == "raw":
+        return frame.drop(columns=list(RAW_DROP_COLUMNS), errors="ignore")
+    if recipe == "spaceship_inductive":
+        return _spaceship_features(frame, include_cohort_features=False)
+    if recipe in {"spaceship_cohort", "spaceship_basic"}:
+        return _spaceship_features(frame, include_cohort_features=True)
+    if recipe == "spaceship_inductive_v2":
+        return _spaceship_features_v2(frame, include_cohort_features=False)
+    if recipe == "spaceship_cohort_v2":
+        return _spaceship_features_v2(frame, include_cohort_features=True)
+    raise ValueError(
+        "recipe must be one of: raw, spaceship_inductive, spaceship_cohort, "
+        "spaceship_basic, spaceship_inductive_v2, spaceship_cohort_v2."
+    )
+
+
+def _spaceship_features(
+    frame: pd.DataFrame, *, include_cohort_features: bool
+) -> pd.DataFrame:
+    result = frame.copy()
+    passenger_parts = result["PassengerId"].astype("string").str.split("_", expand=True)
+    passenger_parts = passenger_parts.reindex(columns=range(2))
+    result["PassengerGroup"] = passenger_parts[0].fillna("unknown")
+    result["PassengerNumber"] = pd.to_numeric(passenger_parts[1], errors="coerce")
+    if include_cohort_features:
+        group_sizes = result.groupby("PassengerGroup")["PassengerGroup"].transform(
+            "size"
+        )
+        result["PassengerGroupSize"] = group_sizes
+        result["PassengerGroupIsSolo"] = group_sizes.eq(1)
+
+    cabin_parts = result["Cabin"].astype("string").str.split("/", expand=True)
+    cabin_parts = cabin_parts.reindex(columns=range(3))
+    result["CabinDeck"] = cabin_parts[0].fillna("Unknown")
+    result["CabinNumber"] = pd.to_numeric(cabin_parts[1], errors="coerce")
+    result["CabinSide"] = cabin_parts[2].fillna("Unknown")
+
+    spending_columns = ["RoomService", "FoodCourt", "ShoppingMall", "Spa", "VRDeck"]
+    existing_spending_columns = [
+        column for column in spending_columns if column in result.columns
+    ]
+    spending = result[existing_spending_columns].apply(pd.to_numeric, errors="coerce")
+    result["SpendingTotal"] = spending.sum(axis=1, min_count=1)
+    result["SpendingAny"] = result["SpendingTotal"].gt(0)
+    result["SpendingMissingCount"] = spending.isna().sum(axis=1)
+
+    return result.drop(
+        columns=[
+            column
+            for column in SPACESHIP_BASIC_DROP_COLUMNS
+            if column in result.columns
+        ],
+        errors="ignore",
+    )
+
+
+def _spaceship_features_v2(
+    frame: pd.DataFrame, *, include_cohort_features: bool
+) -> pd.DataFrame:
+    """Produce target-free, documented Spaceship Titanic domain features."""
+    result = _spaceship_features(frame, include_cohort_features=include_cohort_features)
+    source = frame.reset_index(drop=True)
+    result = result.reset_index(drop=True)
+
+    names = source["Name"].astype("string")
+    result["FamilyName"] = (
+        names.str.rsplit(n=1).str[-1].fillna("Unknown").str.strip().str.lower()
+    )
+    result["NameMissing"] = names.isna()
+    if include_cohort_features:
+        family_sizes = result.groupby("FamilyName")["FamilyName"].transform("size")
+        result["FamilyBatchSize"] = family_sizes
+        result["FamilyBatchShared"] = family_sizes.gt(1)
+
+    age = pd.to_numeric(source["Age"], errors="coerce")
+    result["AgeMissing"] = age.isna()
+    result["IsChild"] = age.lt(13)
+    result["AgeBand"] = (
+        pd.cut(
+            age,
+            bins=[-np.inf, 12, 17, 25, 39, 59, np.inf],
+            labels=["child", "teen", "young_adult", "adult", "middle_age", "senior"],
+        )
+        .astype("string")
+        .fillna("Unknown")
+    )
+
+    cabin_number = pd.to_numeric(result["CabinNumber"], errors="coerce")
+    result["CabinMissing"] = source["Cabin"].isna()
+    result["CabinNumberBand"] = (
+        (cabin_number // 100).astype("Int64").astype("string").fillna("Unknown")
+    )
+
+    spending_columns = ["RoomService", "FoodCourt", "ShoppingMall", "Spa", "VRDeck"]
+    spending = source[spending_columns].apply(pd.to_numeric, errors="coerce")
+    observed_spending = spending.fillna(0)
+    result["NoSpend"] = observed_spending.sum(axis=1).eq(0)
+    result["AmenitiesUsed"] = observed_spending.gt(0).sum(axis=1)
+    result["ServiceSpend"] = observed_spending[["RoomService", "FoodCourt"]].sum(axis=1)
+    result["LuxurySpend"] = observed_spending[["ShoppingMall", "Spa", "VRDeck"]].sum(
+        axis=1
+    )
+    result["LogSpendingTotal"] = np.log1p(observed_spending.sum(axis=1))
+    cryo_sleep = source["CryoSleep"].astype("boolean").fillna(False)
+    result["CryoSpendConflict"] = cryo_sleep & ~result["NoSpend"]
+
+    return result
+
+
+def passenger_groups(frame: pd.DataFrame) -> pd.Series:
+    return (
+        frame["PassengerId"]
+        .astype("string")
+        .str.split("_", n=1, expand=True)[0]
+        .fillna("unknown")
+    )
+
+
+def household_components(frame: pd.DataFrame) -> pd.Series:
+    """Join passenger groups sharing a known family name for sensitivity testing."""
+    passenger = passenger_groups(frame).reset_index(drop=True)
+    family = (
+        frame["Name"]
+        .astype("string")
+        .str.rsplit(n=1)
+        .str[-1]
+        .str.strip()
+        .str.lower()
+        .reset_index(drop=True)
+    )
+    parents: dict[str, str] = {}
+
+    def find(value: str) -> str:
+        parents.setdefault(value, value)
+        if parents[value] != value:
+            parents[value] = find(parents[value])
+        return parents[value]
+
+    def union(left: str, right: str) -> None:
+        left_root, right_root = find(left), find(right)
+        if left_root != right_root:
+            parents[right_root] = left_root
+
+    for group, surname in zip(passenger, family):
+        group_key = f"group:{group}"
+        find(group_key)
+        if pd.notna(surname) and surname != "":
+            union(group_key, f"family:{surname}")
+
+    return passenger.map(lambda group: find(f"group:{group}"))
+
+
+def validation_groups(frame: pd.DataFrame, group_scope: GroupScope) -> pd.Series:
+    if group_scope == "passenger":
+        return passenger_groups(frame)
+    if group_scope == "household_component":
+        return household_components(frame)
+    raise ValueError("group_scope must be one of: passenger, household_component.")
+
+
+def validate_recipe_scope(recipe: RecipeName, group_scope: GroupScope) -> None:
+    is_cohort_recipe = recipe == "spaceship_cohort_v2"
+    has_safe_scope = group_scope == "household_component"
+    invalid_cohort_scope = is_cohort_recipe and not has_safe_scope
+    if invalid_cohort_scope:
+        raise ValueError(
+            "spaceship_cohort_v2 requires group_scope='household_component' so "
+            "batch-level family features remain fold-disjoint."
+        )
+
+
+def split_spaceship_validation(
+    train: pd.DataFrame,
+    *,
+    validation_protocol: ValidationProtocol,
+    holdout_size: float,
+    random_state: int,
+    run: int = 0,
+    group_scope: GroupScope = "passenger",
+) -> tuple[pd.DataFrame, pd.DataFrame, pd.Series | None, pd.Series | None]:
+    y = train["Transported"].astype(bool).reset_index(drop=True)
+    groups = validation_groups(train, group_scope).reset_index(drop=True)
+    if validation_protocol == "grouped":
+        n_splits = max(2, int(round(1 / holdout_size)))
+        n_splits = min(n_splits, int(groups.nunique()))
+        if n_splits < 2:
+            raise ValueError("Grouped validation requires at least two groups.")
+        splitter = StratifiedGroupKFold(
+            n_splits=n_splits,
+            shuffle=True,
+            random_state=random_state + (run // n_splits),
+        )
+        folds = list(splitter.split(train, y, groups))
+        modeling_idx, holdout_idx = folds[run % len(folds)]
+        return (
+            train.iloc[modeling_idx],
+            train.iloc[holdout_idx],
+            groups.iloc[modeling_idx].reset_index(drop=True),
+            groups.iloc[holdout_idx].reset_index(drop=True),
+        )
+    if validation_protocol == "row":
+        modeling_raw, holdout_raw = train_test_split(
+            train,
+            test_size=holdout_size,
+            stratify=y,
+            random_state=random_state + run,
+        )
+        return modeling_raw, holdout_raw, None, None
+    raise ValueError("validation_protocol must be one of: grouped, row.")
+
+
+def reserve_confirmation_partition(
+    train: pd.DataFrame,
+    *,
+    validation_protocol: ValidationProtocol,
+    group_scope: GroupScope,
+    confirmation_size: float,
+    confirmation_seed: int,
+) -> tuple[pd.DataFrame, pd.DataFrame, pd.Series | None, pd.Series | None]:
+    return split_spaceship_validation(
+        train,
+        validation_protocol=validation_protocol,
+        holdout_size=confirmation_size,
+        random_state=confirmation_seed,
+        group_scope=group_scope,
+    )
+
+
+def run_spaceship_benchmark(
+    train: pd.DataFrame,
+    test: pd.DataFrame,
+    *,
+    config: BenchmarkConfig,
+) -> tuple[pd.DataFrame, dict, list[dict]]:
+    rows = []
+    prediction_rows = []
+    diagnostics = []
+    validate_recipe_scope(config.recipe, config.group_scope)
+
+    for run in range(config.runs):
+        run_random_state = config.random_state + run
+        modeling_raw, holdout_raw, groups_modeling, groups_holdout = (
+            split_spaceship_validation(
+                train,
+                validation_protocol=config.validation_protocol,
+                holdout_size=config.holdout_size,
+                random_state=config.random_state,
+                run=run,
+                group_scope=config.group_scope,
+            )
+        )
+        X_modeling, y_modeling, X_holdout, y_holdout = prepare_spaceship_modeling_split(
+            modeling_raw,
+            holdout_raw,
+            recipe=config.recipe,
+        )
+        start_time = time.perf_counter()
+        model = _make_mamut(config, random_state=run_random_state, final_refit=True)
+        model.fit(
+            X_modeling,
+            y_modeling,
+            X_holdout=X_holdout,
+            y_holdout=y_holdout,
+            groups=groups_modeling,
+            groups_holdout=groups_holdout,
+        )
+        baseline_comparison, leakage_checks, group_overlap = benchmark_integrity_audit(
+            model,
+            X_modeling=X_modeling,
+            y_modeling=y_modeling,
+            X_evaluation=X_holdout,
+            y_evaluation=y_holdout,
+            groups_modeling=groups_modeling,
+            groups_evaluation=groups_holdout,
+        )
+        duration_seconds = time.perf_counter() - start_time
+
+        selected_model = model.selected_estimator_.__class__.__name__
+        audit_candidates = model.holdout_summary_.sort_values(
+            "accuracy_score", ascending=False
+        )
+        best_audit_candidate = audit_candidates.iloc[0]
+        best_baseline = _best_baseline_row(baseline_comparison)
+        leakage_warnings = int(
+            leakage_checks["severity"].isin(["warning", "critical"]).sum()
+        )
+
+        selected_score = float(model.holdout_score_)
+        best_audit_score = float(best_audit_candidate["accuracy_score"])
+        baseline_score = _safe_float(best_baseline.get("score"))
+        baseline_available = pd.notna(baseline_score)
+        exceeds_margin = (
+            baseline_score - selected_score > config.selection_practical_margin
+        )
+        baseline_challenge = baseline_available and exceeds_margin
+        selected_predictions = np.asarray(model.predict(X_holdout)).astype(bool)
+        holdout_truth = y_holdout.to_numpy(dtype=bool)
+        repeat = run // max(2, int(round(1 / config.holdout_size)))
+        for group, truth, prediction in zip(
+            groups_holdout if groups_holdout is not None else range(len(X_holdout)),
+            holdout_truth,
+            selected_predictions,
+        ):
+            prediction_rows.append(
+                {
+                    "repeat": repeat,
+                    "group": str(group),
+                    "correct": bool(truth == prediction),
+                }
+            )
+        rows.append(
+            {
+                "competition": config.competition,
+                "recipe": config.recipe,
+                "validation_protocol": config.validation_protocol,
+                "group_scope": config.group_scope,
+                "stage": config.stage,
+                "run": run,
+                "random_state": run_random_state,
+                "train_rows": len(X_modeling),
+                "holdout_rows": len(X_holdout),
+                "features": X_modeling.shape[1],
+                "selected_model": selected_model,
+                "selected_holdout_score": selected_score,
+                "best_audit_candidate_model": best_audit_candidate["model"],
+                "best_audit_candidate_holdout_score": best_audit_score,
+                "audit_candidate_delta": best_audit_score - selected_score,
+                "best_baseline_model": best_baseline.get("model", ""),
+                "best_baseline_score": baseline_score,
+                "baseline_uplift": (
+                    selected_score - baseline_score
+                    if pd.notna(baseline_score)
+                    else np.nan
+                ),
+                "guidance_status": (
+                    "challenged_by_fixed_baseline"
+                    if baseline_challenge
+                    else "confirmed_against_fixed_baselines"
+                ),
+                "guidance_recommended_model": selected_model,
+                "leakage_warnings": leakage_warnings,
+                "evaluation_group_overlap": group_overlap,
+                "duration_seconds": duration_seconds,
+            }
+        )
+        diagnostics.append(
+            {
+                "run": run,
+                "selection_summary": model.selection_summary_.to_dict(orient="records"),
+                "candidate_holdout_audit_only": audit_candidates.to_dict(
+                    orient="records"
+                ),
+                "fixed_baseline_comparison": baseline_comparison.to_dict(
+                    orient="records"
+                ),
+                "leakage_checks": leakage_checks.to_dict(orient="records"),
+            }
+        )
+
+    run_results = pd.DataFrame(rows)
+    aggregate = summarize_runs(
+        run_results,
+        score_column="selected_holdout_score",
+        predictions=pd.DataFrame(prediction_rows),
+        random_state=config.random_state,
+    )
+    return run_results, aggregate, diagnostics
+
+
+def summarize_runs(
+    run_results: pd.DataFrame,
+    *,
+    score_column: str,
+    predictions: pd.DataFrame | None = None,
+    random_state: int = 42,
+) -> dict:
+    scores = run_results[score_column].dropna().astype(float)
+    audit_deltas = run_results["audit_candidate_delta"].dropna().astype(float)
+    baseline_uplifts = run_results["baseline_uplift"].dropna().astype(float)
+    stability_low = _safe_float(scores.min())
+    stability_high = _safe_float(scores.max())
+    bootstrap_low, bootstrap_high = group_bootstrap_accuracy_interval(
+        predictions, random_state=random_state
+    )
+
+    return {
+        "runs": int(len(run_results)),
+        "mean_score": _safe_float(scores.mean()),
+        "std_score": _safe_float(scores.std(ddof=1)) if len(scores) > 1 else 0.0,
+        "stability_low": stability_low,
+        "stability_high": stability_high,
+        "group_bootstrap_low": bootstrap_low,
+        "group_bootstrap_high": bootstrap_high,
+        "interval_method": "group bootstrap of recorded outer predictions",
+        "best_run_score": _safe_float(scores.max()),
+        "worst_run_score": _safe_float(scores.min()),
+        "mean_audit_candidate_delta": _safe_float(audit_deltas.mean()),
+        "median_audit_candidate_delta": _safe_float(audit_deltas.median()),
+        "p90_audit_candidate_delta": _safe_float(audit_deltas.quantile(0.90)),
+        "mean_baseline_uplift": _safe_float(baseline_uplifts.mean()),
+        "challenged_rate": _safe_float(
+            run_results["guidance_status"].str.contains("challenged").mean()
+        ),
+        "total_duration_seconds": _safe_float(run_results["duration_seconds"].sum()),
+    }
+
+
+def group_bootstrap_accuracy_interval(
+    predictions: pd.DataFrame | None,
+    *,
+    random_state: int,
+    n_resamples: int = 2000,
+    confidence_level: float = 0.95,
+) -> tuple[float, float]:
+    if predictions is None or predictions.empty:
+        return np.nan, np.nan
+    rng = np.random.default_rng(random_state)
+    frames = [frame for _, frame in predictions.groupby("repeat", sort=True)]
+    samples = []
+    for _ in range(n_resamples):
+        correctness = []
+        for frame in frames:
+            grouped = {
+                group: values["correct"].to_numpy(dtype=float)
+                for group, values in frame.groupby("group", sort=False)
+            }
+            group_names = list(grouped)
+            chosen = rng.choice(group_names, size=len(group_names), replace=True)
+            correctness.extend(
+                value for group in chosen for value in grouped[str(group)]
+            )
+        samples.append(float(np.mean(correctness)))
+    alpha = (1 - confidence_level) / 2
+    return tuple(float(value) for value in np.quantile(samples, [alpha, 1 - alpha]))
+
+
+def benchmark_integrity_audit(
+    model: Mamut,
+    *,
+    X_modeling: pd.DataFrame,
+    y_modeling: pd.Series,
+    X_evaluation: pd.DataFrame,
+    y_evaluation: pd.Series,
+    groups_modeling: pd.Series | None,
+    groups_evaluation: pd.Series | None,
+) -> tuple[pd.DataFrame, pd.DataFrame, float]:
+    baseline_comparison = evaluate_estimators_on_split(
+        estimators=default_baseline_estimators(random_state=model.random_state),
+        X_train=X_modeling,
+        y_train=y_modeling,
+        X_evaluation=X_evaluation,
+        y_evaluation=y_evaluation,
+        metric_name=model.score_metric_name,
+        binary=model.binary,
+        preprocessor_factory=model._make_model_preprocessor,
+    )
+    leakage_checks = detect_leakage_risks(X_modeling, y_modeling)
+    if groups_modeling is None or groups_evaluation is None:
+        group_overlap = np.nan
+    else:
+        group_overlap = float(
+            len(set(groups_modeling).intersection(set(groups_evaluation)))
+        )
+    return baseline_comparison, leakage_checks, group_overlap
+
+
+def run_confirmation_benchmark(
+    development: pd.DataFrame,
+    confirmation: pd.DataFrame,
+    development_groups: pd.Series | None,
+    confirmation_groups: pd.Series | None,
+    *,
+    config: BenchmarkConfig,
+) -> tuple[pd.DataFrame, dict, list[dict]]:
+    validate_recipe_scope(config.recipe, config.group_scope)
+    X_development, y_development, X_confirmation, y_confirmation = (
+        prepare_spaceship_modeling_split(
+            development,
+            confirmation,
+            recipe=config.recipe,
+        )
+    )
+    start_time = time.perf_counter()
+    model = _make_mamut(config, random_state=config.random_state, final_refit=True)
+    model.fit(
+        X_development,
+        y_development,
+        groups=development_groups,
+    )
+    baseline_comparison, leakage_checks, group_overlap = benchmark_integrity_audit(
+        model,
+        X_modeling=X_development,
+        y_modeling=y_development,
+        X_evaluation=X_confirmation,
+        y_evaluation=y_confirmation,
+        groups_modeling=development_groups,
+        groups_evaluation=confirmation_groups,
+    )
+    duration_seconds = time.perf_counter() - start_time
+    selected_model = model.selected_estimator_.__class__.__name__
+    best_baseline = _best_baseline_row(baseline_comparison)
+    predictions = np.asarray(model.predict(X_confirmation)).astype(bool)
+    selected_score = float(model.score_metric(y_confirmation, predictions))
+    baseline_score = _safe_float(best_baseline.get("score"))
+    truth = y_confirmation.to_numpy(dtype=bool)
+    recorded_predictions = pd.DataFrame(
+        {
+            "repeat": 0,
+            "group": [
+                str(value)
+                for value in (
+                    confirmation_groups
+                    if confirmation_groups is not None
+                    else range(len(X_confirmation))
+                )
+            ],
+            "correct": truth == predictions,
+        }
+    )
+    run_results = pd.DataFrame(
+        [
+            {
+                "competition": config.competition,
+                "recipe": config.recipe,
+                "validation_protocol": config.validation_protocol,
+                "group_scope": config.group_scope,
+                "stage": "confirmation",
+                "run": 0,
+                "random_state": config.random_state,
+                "train_rows": len(X_development),
+                "holdout_rows": len(X_confirmation),
+                "features": X_development.shape[1],
+                "selected_model": selected_model,
+                "selected_holdout_score": selected_score,
+                "best_audit_candidate_model": "not evaluated for confirmation",
+                "best_audit_candidate_holdout_score": np.nan,
+                "audit_candidate_delta": np.nan,
+                "best_baseline_model": best_baseline.get("model", ""),
+                "best_baseline_score": baseline_score,
+                "baseline_uplift": (
+                    selected_score - baseline_score
+                    if pd.notna(baseline_score)
+                    else np.nan
+                ),
+                "guidance_status": "confirmation_observation_only",
+                "guidance_recommended_model": selected_model,
+                "leakage_warnings": int(
+                    leakage_checks["severity"].isin(["warning", "critical"]).sum()
+                ),
+                "evaluation_group_overlap": group_overlap,
+                "duration_seconds": duration_seconds,
+            }
+        ]
+    )
+    aggregate = summarize_runs(
+        run_results,
+        score_column="selected_holdout_score",
+        predictions=recorded_predictions,
+        random_state=config.random_state,
+    )
+    aggregate["confirmation_observation_only"] = True
+    diagnostics = [
+        {
+            "run": 0,
+            "selection_summary": model.selection_summary_.to_dict(orient="records"),
+            "fixed_baseline_comparison": baseline_comparison.to_dict(orient="records"),
+            "leakage_checks": leakage_checks.to_dict(orient="records"),
+            "candidate_holdout_audit_only": "not evaluated during confirmation",
+        }
+    ]
+    return run_results, aggregate, diagnostics
+
+
+def fit_submission_model(
+    train: pd.DataFrame,
+    test: pd.DataFrame,
+    *,
+    config: BenchmarkConfig,
+) -> tuple[pd.DataFrame, Mamut]:
+    X, y, X_test, passenger_ids = prepare_spaceship_features(
+        train, test, recipe=config.recipe
+    )
+    model = _make_mamut(config, random_state=config.random_state, final_refit=True)
+    groups = (
+        validation_groups(train, config.group_scope)
+        if config.validation_protocol == "grouped"
+        else None
+    )
+    model.fit(X, y, groups=groups)
+    predictions = _coerce_bool_predictions(model.predict(X_test))
+    submission = pd.DataFrame(
+        {"PassengerId": passenger_ids, "Transported": predictions}
+    )
+    return submission, model
+
+
+def write_submission(submission: pd.DataFrame, path: Path) -> Path:
+    if list(submission.columns) != ["PassengerId", "Transported"]:
+        raise ValueError("Submission must contain columns: PassengerId, Transported.")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    submission.to_csv(path, index=False)
+    return path
+
+
+def submit_to_kaggle(
+    competition: CompetitionName, submission_path: Path, message: str
+) -> None:
+    subprocess.run(
+        [
+            "kaggle",
+            "competitions",
+            "submit",
+            "-c",
+            competition,
+            "-f",
+            str(submission_path),
+            "-m",
+            message,
+        ],
+        check=True,
+    )
+
+
+def build_metadata(data_dir: Path) -> BenchmarkMetadata:
+    return BenchmarkMetadata(
+        generated_at_utc=datetime.now(timezone.utc).isoformat(),
+        mamut_version=mamut.__version__,
+        git_commit=_git_commit(),
+        train_sha256=_sha256(data_dir / "train.csv"),
+        test_sha256=_sha256(data_dir / "test.csv"),
+        sample_submission_sha256=_sha256(data_dir / "sample_submission.csv"),
+        git_branch=_git_branch(),
+        git_dirty=_git_dirty(),
+        python_version=platform.python_version(),
+        feature_recipe_version=FEATURE_RECIPE_VERSION,
+    )
+
+
+def format_results(payload: dict, output_format: OutputFormat) -> str:
+    run_results = pd.DataFrame(payload["runs"])
+    aggregate = pd.DataFrame([payload["aggregate"]])
+    if output_format == "json":
+        return json.dumps(_json_ready(payload), indent=2, allow_nan=False)
+    if output_format == "csv":
+        return run_results.to_csv(index=False, float_format="%.6f")
+    if output_format == "markdown":
+        return "\n".join(
+            [
+                "## Aggregate",
+                _to_markdown(_display_scores(aggregate)),
+                "",
+                "## Runs",
+                _to_markdown(_display_scores(run_results)),
+            ]
+        )
+    raise ValueError("Unsupported output format.")
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Run external Kaggle benchmarks for MAMUT."
+    )
+    parser.add_argument("competition", choices=["spaceship-titanic"])
+    parser.add_argument(
+        "--recipe",
+        choices=[
+            "raw",
+            "spaceship_inductive",
+            "spaceship_cohort",
+            "spaceship_basic",
+            "spaceship_inductive_v2",
+            "spaceship_cohort_v2",
+        ],
+        default="spaceship_inductive_v2",
+    )
+    parser.add_argument(
+        "--stage",
+        choices=["diagnostic", "development", "confirmation"],
+        default="development",
+        help="Reserve a locked confirmation partition unless running legacy diagnostics.",
+    )
+    parser.add_argument("--runs", type=int, default=3)
+    parser.add_argument("--n-iterations", type=int, default=3)
+    parser.add_argument("--random-state", type=int, default=42)
+    parser.add_argument("--holdout-size", type=float, default=0.2)
+    parser.add_argument(
+        "--validation-protocol", choices=["grouped", "row"], default="grouped"
+    )
+    parser.add_argument(
+        "--group-scope",
+        choices=["passenger", "household_component"],
+        default="passenger",
+    )
+    parser.add_argument("--confirmation-size", type=float, default=0.2)
+    parser.add_argument(
+        "--confirmation-seed", type=int, default=DEFAULT_CONFIRMATION_SEED
+    )
+    parser.add_argument(
+        "--score-metric",
+        choices=["accuracy", "balanced_accuracy", "f1"],
+        default="accuracy",
+    )
+    parser.add_argument(
+        "--search-profile",
+        choices=["quick", "balanced", "thorough"],
+        default="quick",
+    )
+    parser.add_argument(
+        "--selection-strategy",
+        choices=["single_split", "nested_cv", "repeated_cv"],
+        default="nested_cv",
+    )
+    parser.add_argument("--selection-cv-splits", type=int, default=5)
+    parser.add_argument("--selection-cv-repeats", type=int, default=2)
+    parser.add_argument("--selection-practical-margin", type=float, default=0.005)
+    parser.add_argument(
+        "--preprocessing-profile",
+        choices=["auto", "generic_ohe"],
+        default="auto",
+    )
+    parser.add_argument(
+        "--optimization-method",
+        choices=["random_search", "bayes"],
+        default="random_search",
+    )
+    parser.add_argument(
+        "--exclude-models", nargs="*", default=list(DEFAULT_EXCLUDED_MODELS)
+    )
+    parser.add_argument("--include-models", nargs="*", default=None)
+    parser.add_argument("--cache-dir", type=Path, default=DEFAULT_CACHE_DIR)
+    parser.add_argument("--output-dir", type=Path, default=DEFAULT_OUTPUT_DIR)
+    parser.add_argument(
+        "--format", choices=["markdown", "json", "csv"], default="markdown"
+    )
+    parser.add_argument("--force-download", action="store_true")
+    parser.add_argument("--write-submission", action="store_true")
+    parser.add_argument("--submit", action="store_true")
+    parser.add_argument("--submission-message", default=None)
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv)
+    if args.runs < 1:
+        raise ValueError("--runs must be at least 1.")
+    if args.n_iterations < 1:
+        raise ValueError("--n-iterations must be at least 1.")
+    if args.selection_cv_splits < 2:
+        raise ValueError("--selection-cv-splits must be at least 2.")
+    if args.selection_cv_repeats < 1:
+        raise ValueError("--selection-cv-repeats must be at least 1.")
+    if args.selection_practical_margin < 0:
+        raise ValueError("--selection-practical-margin must be non-negative.")
+    if args.submit and not args.write_submission:
+        raise ValueError("--submit requires --write-submission.")
+    if args.write_submission and args.stage != "confirmation":
+        raise ValueError("--write-submission requires --stage confirmation.")
+    if args.include_models and args.exclude_models:
+        raise ValueError("Use --include-models or --exclude-models, not both.")
+    if not 0 < args.confirmation_size < 1:
+        raise ValueError("--confirmation-size must be greater than 0 and less than 1.")
+    validate_recipe_scope(args.recipe, args.group_scope)
+
+    config = BenchmarkConfig(
+        competition=args.competition,
+        recipe=args.recipe,
+        runs=args.runs,
+        n_iterations=args.n_iterations,
+        random_state=args.random_state,
+        holdout_size=args.holdout_size,
+        validation_protocol=args.validation_protocol,
+        score_metric=args.score_metric,
+        search_profile=args.search_profile,
+        selection_strategy=args.selection_strategy,
+        selection_cv_splits=args.selection_cv_splits,
+        selection_cv_repeats=args.selection_cv_repeats,
+        selection_practical_margin=args.selection_practical_margin,
+        preprocessing_profile=args.preprocessing_profile,
+        optimization_method=args.optimization_method,
+        excluded_models=tuple(args.exclude_models),
+        included_models=tuple(args.include_models) if args.include_models else None,
+        group_scope=args.group_scope,
+        stage=args.stage,
+        confirmation_size=args.confirmation_size,
+        confirmation_seed=args.confirmation_seed,
+    )
+
+    data_dir = ensure_competition_data(
+        config.competition,
+        args.cache_dir,
+        force_download=args.force_download,
+    )
+    train, test, _ = load_spaceship_titanic(data_dir)
+    metadata = build_metadata(data_dir)
+    if args.submit and metadata.git_dirty:
+        raise RuntimeError(
+            "Official Kaggle submission requires a clean git working tree so the "
+            "uploaded artifact is reproducible from a recorded commit."
+        )
+    output_dir = args.output_dir / config.competition / config.recipe
+    output_dir.mkdir(parents=True, exist_ok=True)
+    confirmation_marker = (
+        args.output_dir / config.competition / "confirmation_consumed.json"
+    )
+    if args.stage == "confirmation" and confirmation_marker.exists():
+        raise RuntimeError(
+            "The reserved confirmation partition has already been evaluated for this "
+            "campaign. Start a separately documented campaign instead of reusing it."
+        )
+
+    partitions = {
+        "official_train_rows": len(train),
+        "official_test_rows": len(test),
+        "confirmation_reserved": args.stage != "diagnostic",
+    }
+    if args.stage == "diagnostic":
+        run_results, aggregate, diagnostics = run_spaceship_benchmark(
+            train, test, config=config
+        )
+    else:
+        development, confirmation, development_groups, confirmation_groups = (
+            reserve_confirmation_partition(
+                train,
+                validation_protocol=config.validation_protocol,
+                group_scope=config.group_scope,
+                confirmation_size=config.confirmation_size,
+                confirmation_seed=config.confirmation_seed,
+            )
+        )
+        partitions.update(
+            {
+                "development_rows": len(development),
+                "confirmation_rows": len(confirmation),
+                "confirmation_seed": config.confirmation_seed,
+                "confirmation_size": config.confirmation_size,
+            }
+        )
+        if args.stage == "development":
+            run_results, aggregate, diagnostics = run_spaceship_benchmark(
+                development, test, config=config
+            )
+        else:
+            run_results, aggregate, diagnostics = run_confirmation_benchmark(
+                development,
+                confirmation,
+                development_groups,
+                confirmation_groups,
+                config=config,
+            )
+
+    payload = {
+        "metadata": asdict(metadata),
+        "config": asdict(config),
+        "partitions": partitions,
+        "protocol": {
+            "primary_metric": config.score_metric,
+            "grouped_validation": config.validation_protocol == "grouped",
+            "development_interval": (
+                "Group bootstrap interval of recorded outer predictions; it "
+                "does not represent post-selection confirmation."
+            ),
+            "confirmation_policy": (
+                "Confirmation scores are observations of a frozen candidate and "
+                "must not be used to promote an alternative model."
+            ),
+        },
+        "aggregate": aggregate,
+        "runs": run_results.to_dict(orient="records"),
+        "diagnostics": diagnostics,
+        "submission": {"generated": False, "uploaded": False},
+    }
+    results_path = output_dir / "latest_results.json"
+    manifest_path = output_dir / "experiment_manifest.json"
+
+    write_campaign_artifacts(payload, results_path, manifest_path)
+    if args.stage == "confirmation":
+        confirmation_marker.write_text(
+            json.dumps(
+                {
+                    "generated_at_utc": metadata.generated_at_utc,
+                    "git_commit": metadata.git_commit,
+                    "recipe": config.recipe,
+                    "config": asdict(config),
+                    "result_path": str(results_path),
+                },
+                indent=2,
+            ),
+            encoding="utf-8",
+        )
+
+    if args.write_submission:
+        submission, _ = fit_submission_model(train, test, config=config)
+        submission_path = output_dir / "submission.csv"
+        write_submission(submission, submission_path)
+        payload["submission"] = {
+            "generated": True,
+            "uploaded": False,
+            "path": str(submission_path),
+        }
+        write_campaign_artifacts(payload, results_path, manifest_path)
+        if args.submit:
+            message = args.submission_message or _default_submission_message(
+                config, metadata
+            )
+            submit_to_kaggle(config.competition, submission_path, message)
+            payload["submission"] = {
+                "generated": True,
+                "uploaded": True,
+                "path": str(submission_path),
+                "message": message,
+            }
+            write_campaign_artifacts(payload, results_path, manifest_path)
+    print(format_results(payload, args.format))
+    return 0
+
+
+def write_campaign_artifacts(
+    payload: dict, results_path: Path, manifest_path: Path
+) -> None:
+    manifest_path.write_text(
+        json.dumps(
+            _json_ready(
+                {
+                    "metadata": payload["metadata"],
+                    "config": payload["config"],
+                    "partitions": payload["partitions"],
+                    "protocol": payload["protocol"],
+                    "submission": payload["submission"],
+                }
+            ),
+            indent=2,
+            allow_nan=False,
+        ),
+        encoding="utf-8",
+    )
+    payload["manifest_path"] = str(manifest_path)
+    results_path.write_text(
+        json.dumps(_json_ready(payload), indent=2, allow_nan=False),
+        encoding="utf-8",
+    )
+
+
+def _make_mamut(
+    config: BenchmarkConfig, *, random_state: int, final_refit: bool
+) -> Mamut:
+    return Mamut(
+        score_metric=config.score_metric,
+        search_profile=config.search_profile,
+        selection_strategy=config.selection_strategy,
+        selection_cv_splits=config.selection_cv_splits,
+        selection_cv_repeats=config.selection_cv_repeats,
+        selection_practical_margin=config.selection_practical_margin,
+        preprocessing_profile=config.preprocessing_profile,
+        optimization_method=config.optimization_method,
+        n_iterations=config.n_iterations,
+        random_state=random_state,
+        exclude_models=list(config.excluded_models),
+        include_models=(
+            list(config.included_models) if config.included_models is not None else None
+        ),
+        refit_final_model=final_refit,
+        num_imputation="mean",
+        evidence_cv_splits=3,
+        evidence_cv_repeats=1,
+    )
+
+
+def _metric_column(score_metric: str) -> str:
+    return {
+        "accuracy": "accuracy_score",
+        "balanced_accuracy": "balanced_accuracy_score",
+        "f1": "f1_score",
+    }[score_metric]
+
+
+def _best_baseline_row(baseline_comparison: pd.DataFrame) -> pd.Series:
+    baselines = baseline_comparison.loc[
+        ~baseline_comparison["model"].str.startswith("MAMUT ")
+    ].dropna(subset=["score"])
+    if baselines.empty:
+        return pd.Series({"model": "", "score": np.nan})
+    return baselines.sort_values("score", ascending=False).iloc[0]
+
+
+def _safe_float(value) -> float:
+    if pd.isna(value):
+        return np.nan
+    return float(value)
+
+
+def _coerce_bool_predictions(predictions: Iterable) -> list[bool]:
+    result = []
+    for prediction in predictions:
+        if isinstance(prediction, (bool, np.bool_)):
+            result.append(bool(prediction))
+        elif isinstance(prediction, str):
+            normalized = prediction.strip().lower()
+            if normalized not in {"true", "false"}:
+                raise ValueError(f"Cannot coerce prediction {prediction!r} to bool.")
+            result.append(normalized == "true")
+        else:
+            result.append(bool(prediction))
+    return result
+
+
+def _sha256(path: Path) -> str:
+    hasher = hashlib.sha256()
+    with path.open("rb") as file:
+        for chunk in iter(lambda: file.read(1024 * 1024), b""):
+            hasher.update(chunk)
+    return hasher.hexdigest()
+
+
+def _git_commit() -> str:
+    try:
+        return subprocess.check_output(
+            ["git", "rev-parse", "--short", "HEAD"], text=True
+        ).strip()
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return "unknown"
+
+
+def _git_branch() -> str:
+    try:
+        return subprocess.check_output(
+            ["git", "branch", "--show-current"], text=True
+        ).strip()
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return "unknown"
+
+
+def _git_dirty() -> bool:
+    try:
+        return bool(
+            subprocess.check_output(
+                ["git", "status", "--porcelain", "--untracked-files=all"],
+                text=True,
+            ).strip()
+        )
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return True
+
+
+def _default_submission_message(
+    config: BenchmarkConfig, metadata: BenchmarkMetadata
+) -> str:
+    return (
+        f"MAMUT {metadata.mamut_version} {config.recipe} "
+        f"runs={config.runs} n_iter={config.n_iterations} commit={metadata.git_commit}"
+    )
+
+
+def _json_ready(value):
+    if isinstance(value, dict):
+        return {key: _json_ready(item) for key, item in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_json_ready(item) for item in value]
+    if isinstance(value, (np.integer,)):
+        return int(value)
+    if isinstance(value, (np.floating,)):
+        value = float(value)
+    if isinstance(value, float) and not np.isfinite(value):
+        return None
+    if isinstance(value, (np.bool_,)):
+        return bool(value)
+    return value
+
+
+def _display_scores(frame: pd.DataFrame) -> pd.DataFrame:
+    display = frame.copy()
+    score_like = [
+        column
+        for column in display.columns
+        if any(
+            token in column
+            for token in (
+                "score",
+                "regret",
+                "uplift",
+                "rate",
+                "ci_",
+                "stability",
+                "bootstrap",
+            )
+        )
+    ]
+    for column in score_like:
+        display[column] = display[column].map(_format_score)
+    if "duration_seconds" in display.columns:
+        display["duration_seconds"] = display["duration_seconds"].map(
+            lambda value: f"{float(value):.1f}"
+        )
+    if "total_duration_seconds" in display.columns:
+        display["total_duration_seconds"] = display["total_duration_seconds"].map(
+            lambda value: f"{float(value):.1f}"
+        )
+    return display
+
+
+def _format_score(value) -> str:
+    if pd.isna(value):
+        return "n/a"
+    return f"{float(value):.4f}"
+
+
+def _to_markdown(table: pd.DataFrame) -> str:
+    headers = list(table.columns)
+    rows = [[str(value) for value in row] for row in table.to_numpy()]
+    widths = [
+        max(len(str(header)), max((len(row[index]) for row in rows), default=0))
+        for index, header in enumerate(headers)
+    ]
+    header_line = _format_markdown_row([str(header) for header in headers], widths)
+    separator_line = _format_markdown_row(["-" * width for width in widths], widths)
+    row_lines = [_format_markdown_row(row, widths) for row in rows]
+    return "\n".join([header_line, separator_line, *row_lines])
+
+
+def _format_markdown_row(values: list[str], widths: list[int]) -> str:
+    padded_values = [value.ljust(widths[index]) for index, value in enumerate(values)]
+    return f"| {' | '.join(padded_values)} |"
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/benchmark_kaggle.py
+++ b/scripts/benchmark_kaggle.py
@@ -5,7 +5,9 @@ import argparse
 import hashlib
 import json
 import platform
+import re
 import subprocess
+import sys
 import time
 import warnings
 from dataclasses import asdict, dataclass
@@ -33,6 +35,7 @@ RecipeName = Literal[
     "spaceship_basic",
     "spaceship_inductive_v2",
     "spaceship_cohort_v2",
+    "spaceship_competition_v3",
 ]
 ValidationProtocol = Literal["grouped", "row"]
 GroupScope = Literal["passenger", "household_component"]
@@ -52,7 +55,7 @@ SPACESHIP_BASIC_DROP_COLUMNS = (
 )
 DEFAULT_EXCLUDED_MODELS = ()
 DEFAULT_CONFIRMATION_SEED = 20260524
-FEATURE_RECIPE_VERSION = "2"
+FEATURE_RECIPE_VERSION = "3"
 
 warnings.filterwarnings(
     "ignore",
@@ -89,6 +92,8 @@ class BenchmarkConfig:
     stage: BenchmarkStage = "diagnostic"
     confirmation_size: float = 0.2
     confirmation_seed: int = DEFAULT_CONFIRMATION_SEED
+    campaign_id: str = "exploration"
+    max_runtime_seconds: float | None = None
 
 
 @dataclass(frozen=True)
@@ -197,6 +202,7 @@ def prepare_spaceship_features(
         "spaceship_basic",
         "spaceship_inductive_v2",
         "spaceship_cohort_v2",
+        "spaceship_competition_v3",
     }:
         X = _spaceship_features_for_recipe(train, recipe).reset_index(drop=True)
         X_test = _spaceship_features_for_recipe(test, recipe).reset_index(drop=True)
@@ -205,7 +211,8 @@ def prepare_spaceship_features(
 
     raise ValueError(
         "recipe must be one of: raw, spaceship_inductive, spaceship_cohort, "
-        "spaceship_basic, spaceship_inductive_v2, spaceship_cohort_v2."
+        "spaceship_basic, spaceship_inductive_v2, spaceship_cohort_v2, "
+        "spaceship_competition_v3."
     )
 
 
@@ -236,9 +243,12 @@ def _spaceship_features_for_recipe(
         return _spaceship_features_v2(frame, include_cohort_features=False)
     if recipe == "spaceship_cohort_v2":
         return _spaceship_features_v2(frame, include_cohort_features=True)
+    if recipe == "spaceship_competition_v3":
+        return _spaceship_features_v2(frame, include_cohort_features=True)
     raise ValueError(
         "recipe must be one of: raw, spaceship_inductive, spaceship_cohort, "
-        "spaceship_basic, spaceship_inductive_v2, spaceship_cohort_v2."
+        "spaceship_basic, spaceship_inductive_v2, spaceship_cohort_v2, "
+        "spaceship_competition_v3."
     )
 
 
@@ -344,18 +354,22 @@ def passenger_groups(frame: pd.DataFrame) -> pd.Series:
     )
 
 
-def household_components(frame: pd.DataFrame) -> pd.Series:
-    """Join passenger groups sharing a known family name for sensitivity testing."""
-    passenger = passenger_groups(frame).reset_index(drop=True)
-    family = (
+def family_names(frame: pd.DataFrame) -> pd.Series:
+    return (
         frame["Name"]
         .astype("string")
         .str.rsplit(n=1)
         .str[-1]
         .str.strip()
         .str.lower()
-        .reset_index(drop=True)
+        .fillna("unknown")
     )
+
+
+def household_components(frame: pd.DataFrame) -> pd.Series:
+    """Join passenger groups sharing a known family name for sensitivity testing."""
+    passenger = passenger_groups(frame).reset_index(drop=True)
+    family = family_names(frame).reset_index(drop=True)
     parents: dict[str, str] = {}
 
     def find(value: str) -> str:
@@ -372,7 +386,7 @@ def household_components(frame: pd.DataFrame) -> pd.Series:
     for group, surname in zip(passenger, family):
         group_key = f"group:{group}"
         find(group_key)
-        if pd.notna(surname) and surname != "":
+        if pd.notna(surname) and surname not in {"", "unknown"}:
             union(group_key, f"family:{surname}")
 
     return passenger.map(lambda group: find(f"group:{group}"))
@@ -395,6 +409,48 @@ def validate_recipe_scope(recipe: RecipeName, group_scope: GroupScope) -> None:
             "spaceship_cohort_v2 requires group_scope='household_component' so "
             "batch-level family features remain fold-disjoint."
         )
+
+
+def validation_estimand(recipe: RecipeName, group_scope: GroupScope) -> str:
+    if group_scope == "household_component":
+        return "generalization to held-out surname-linked household components"
+    if recipe == "spaceship_competition_v3":
+        return (
+            "competition-aligned batch prediction with target-free relational "
+            "features and surname categories allowed to recur across folds"
+        )
+    return (
+        "passenger-group-disjoint prediction; surname categories may recur across "
+        "folds when present in the selected recipe"
+    )
+
+
+def relational_overlap_audit(
+    modeling: pd.DataFrame, evaluation: pd.DataFrame
+) -> list[dict]:
+    """Describe observable identifier recurrence between fitted and scored batches."""
+    key_series = {
+        "PassengerGroup": (passenger_groups(modeling), passenger_groups(evaluation)),
+        "FamilyName": (family_names(modeling), family_names(evaluation)),
+        "Cabin": (
+            modeling["Cabin"].astype("string").str.lower().fillna("unknown"),
+            evaluation["Cabin"].astype("string").str.lower().fillna("unknown"),
+        ),
+    }
+    rows = []
+    for feature, (left, right) in key_series.items():
+        ignored = {"", "unknown"}
+        shared = (set(left) - ignored) & (set(right) - ignored)
+        evaluation_shared = right.isin(shared)
+        rows.append(
+            {
+                "feature": feature,
+                "shared_values": len(shared),
+                "evaluation_rows_with_seen_value": int(evaluation_shared.sum()),
+                "evaluation_fraction_with_seen_value": float(evaluation_shared.mean()),
+            }
+        )
+    return rows
 
 
 def split_spaceship_validation(
@@ -464,6 +520,7 @@ def run_spaceship_benchmark(
     prediction_rows = []
     diagnostics = []
     validate_recipe_scope(config.recipe, config.group_scope)
+    benchmark_start = time.perf_counter()
 
     for run in range(config.runs):
         run_random_state = config.random_state + run
@@ -574,6 +631,9 @@ def run_spaceship_benchmark(
         diagnostics.append(
             {
                 "run": run,
+                "relational_overlap": relational_overlap_audit(
+                    modeling_raw, holdout_raw
+                ),
                 "selection_summary": model.selection_summary_.to_dict(orient="records"),
                 "candidate_holdout_audit_only": audit_candidates.to_dict(
                     orient="records"
@@ -584,6 +644,30 @@ def run_spaceship_benchmark(
                 "leakage_checks": leakage_checks.to_dict(orient="records"),
             }
         )
+        elapsed_seconds = time.perf_counter() - benchmark_start
+        print(
+            (
+                f"[benchmark] completed development run {run + 1}/{config.runs}: "
+                f"selected={selected_model} score={selected_score:.4f} "
+                f"elapsed={elapsed_seconds:.1f}s"
+            ),
+            file=sys.stderr,
+            flush=True,
+        )
+        budget_configured = config.max_runtime_seconds is not None
+        budget_seconds = float(config.max_runtime_seconds or 0)
+        budget_reached = budget_configured and elapsed_seconds >= budget_seconds
+        runs_remaining = run + 1 < config.runs
+        if budget_reached and runs_remaining:
+            print(
+                (
+                    "[benchmark] stopping between completed runs because the soft "
+                    f"runtime budget of {config.max_runtime_seconds:.1f}s was reached."
+                ),
+                file=sys.stderr,
+                flush=True,
+            )
+            break
 
     run_results = pd.DataFrame(rows)
     aggregate = summarize_runs(
@@ -591,6 +675,13 @@ def run_spaceship_benchmark(
         score_column="selected_holdout_score",
         predictions=pd.DataFrame(prediction_rows),
         random_state=config.random_state,
+    )
+    aggregate.update(
+        {
+            "requested_runs": config.runs,
+            "completed_runs": len(run_results),
+            "runtime_budget_exhausted": len(run_results) < config.runs,
+        }
     )
     return run_results, aggregate, diagnostics
 
@@ -790,12 +881,22 @@ def run_confirmation_benchmark(
     diagnostics = [
         {
             "run": 0,
+            "relational_overlap": relational_overlap_audit(development, confirmation),
             "selection_summary": model.selection_summary_.to_dict(orient="records"),
             "fixed_baseline_comparison": baseline_comparison.to_dict(orient="records"),
             "leakage_checks": leakage_checks.to_dict(orient="records"),
             "candidate_holdout_audit_only": "not evaluated during confirmation",
         }
     ]
+    print(
+        (
+            "[benchmark] completed locked confirmation: "
+            f"selected={selected_model} score={selected_score:.4f} "
+            f"elapsed={duration_seconds:.1f}s"
+        ),
+        file=sys.stderr,
+        flush=True,
+    )
     return run_results, aggregate, diagnostics
 
 
@@ -898,8 +999,9 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
             "spaceship_basic",
             "spaceship_inductive_v2",
             "spaceship_cohort_v2",
+            "spaceship_competition_v3",
         ],
-        default="spaceship_inductive_v2",
+        default="spaceship_competition_v3",
     )
     parser.add_argument(
         "--stage",
@@ -922,6 +1024,22 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
     parser.add_argument("--confirmation-size", type=float, default=0.2)
     parser.add_argument(
         "--confirmation-seed", type=int, default=DEFAULT_CONFIRMATION_SEED
+    )
+    parser.add_argument(
+        "--campaign-id",
+        default="exploration",
+        help="Stable identifier used to isolate development and confirmation records.",
+    )
+    parser.add_argument(
+        "--run-id",
+        default=None,
+        help="Optional immutable run directory name; generated automatically by default.",
+    )
+    parser.add_argument(
+        "--max-runtime-seconds",
+        type=float,
+        default=None,
+        help="Soft development budget checked between completed outer runs.",
     )
     parser.add_argument(
         "--score-metric",
@@ -987,6 +1105,11 @@ def main(argv: Sequence[str] | None = None) -> int:
         raise ValueError("Use --include-models or --exclude-models, not both.")
     if not 0 < args.confirmation_size < 1:
         raise ValueError("--confirmation-size must be greater than 0 and less than 1.")
+    if args.max_runtime_seconds is not None and args.max_runtime_seconds <= 0:
+        raise ValueError("--max-runtime-seconds must be greater than zero.")
+    validate_identifier(args.campaign_id, name="campaign-id")
+    if args.run_id is not None:
+        validate_identifier(args.run_id, name="run-id")
     validate_recipe_scope(args.recipe, args.group_scope)
 
     config = BenchmarkConfig(
@@ -1011,6 +1134,8 @@ def main(argv: Sequence[str] | None = None) -> int:
         stage=args.stage,
         confirmation_size=args.confirmation_size,
         confirmation_seed=args.confirmation_seed,
+        campaign_id=args.campaign_id,
+        max_runtime_seconds=args.max_runtime_seconds,
     )
 
     data_dir = ensure_competition_data(
@@ -1025,11 +1150,15 @@ def main(argv: Sequence[str] | None = None) -> int:
             "Official Kaggle submission requires a clean git working tree so the "
             "uploaded artifact is reproducible from a recorded commit."
         )
-    output_dir = args.output_dir / config.competition / config.recipe
-    output_dir.mkdir(parents=True, exist_ok=True)
-    confirmation_marker = (
-        args.output_dir / config.competition / "confirmation_consumed.json"
-    )
+    campaign_dir = args.output_dir / config.competition / config.campaign_id
+    run_id = args.run_id or build_run_id(metadata, config.stage)
+    output_dir = campaign_dir / config.recipe / run_id
+    if output_dir.exists():
+        raise RuntimeError(
+            f"Run directory already exists: {output_dir}. Use a new --run-id."
+        )
+    output_dir.mkdir(parents=True)
+    confirmation_marker = campaign_dir / "confirmation_consumed.json"
     if args.stage == "confirmation" and confirmation_marker.exists():
         raise RuntimeError(
             "The reserved confirmation partition has already been evaluated for this "
@@ -1040,6 +1169,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         "official_train_rows": len(train),
         "official_test_rows": len(test),
         "confirmation_reserved": args.stage != "diagnostic",
+        "official_train_test_relational_overlap": relational_overlap_audit(train, test),
     }
     if args.stage == "diagnostic":
         run_results, aggregate, diagnostics = run_spaceship_benchmark(
@@ -1083,6 +1213,9 @@ def main(argv: Sequence[str] | None = None) -> int:
         "protocol": {
             "primary_metric": config.score_metric,
             "grouped_validation": config.validation_protocol == "grouped",
+            "validation_estimand": validation_estimand(
+                config.recipe, config.group_scope
+            ),
             "development_interval": (
                 "Group bootstrap interval of recorded outer predictions; it "
                 "does not represent post-selection confirmation."
@@ -1096,9 +1229,11 @@ def main(argv: Sequence[str] | None = None) -> int:
         "runs": run_results.to_dict(orient="records"),
         "diagnostics": diagnostics,
         "submission": {"generated": False, "uploaded": False},
+        "campaign_id": config.campaign_id,
+        "run_id": run_id,
     }
-    results_path = output_dir / "latest_results.json"
-    manifest_path = output_dir / "experiment_manifest.json"
+    results_path = output_dir / "results.json"
+    manifest_path = output_dir / "manifest.json"
 
     write_campaign_artifacts(payload, results_path, manifest_path)
     if args.stage == "confirmation":
@@ -1154,6 +1289,8 @@ def write_campaign_artifacts(
                     "partitions": payload["partitions"],
                     "protocol": payload["protocol"],
                     "submission": payload["submission"],
+                    "campaign_id": payload["campaign_id"],
+                    "run_id": payload["run_id"],
                 }
             ),
             indent=2,
@@ -1267,6 +1404,21 @@ def _git_dirty() -> bool:
         )
     except (subprocess.CalledProcessError, FileNotFoundError):
         return True
+
+
+def validate_identifier(value: str, *, name: str) -> None:
+    if not re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9._-]*", value):
+        raise ValueError(
+            f"--{name} must start with an alphanumeric character and contain "
+            "only letters, numbers, '.', '_' or '-'."
+        )
+
+
+def build_run_id(metadata: BenchmarkMetadata, stage: BenchmarkStage) -> str:
+    timestamp = datetime.fromisoformat(metadata.generated_at_utc).strftime(
+        "%Y%m%dT%H%M%S%fZ"
+    )
+    return f"{stage}-{timestamp}-{metadata.git_commit}"
 
 
 def _default_submission_message(

--- a/scripts/benchmark_kaggle.py
+++ b/scripts/benchmark_kaggle.py
@@ -27,6 +27,8 @@ from mamut.evidence import (
     detect_leakage_risks,
     evaluate_estimators_on_split,
 )
+from mamut.model_selection import available_model_names
+from mamut.utils.utils import model_names_for_profile
 
 CompetitionName = Literal["spaceship-titanic"]
 RecipeName = Literal[
@@ -95,6 +97,7 @@ class BenchmarkConfig:
     confirmation_seed: int = DEFAULT_CONFIRMATION_SEED
     campaign_id: str = "exploration"
     max_runtime_seconds: float | None = None
+    n_jobs: int = 1
 
 
 @dataclass(frozen=True)
@@ -424,6 +427,31 @@ def validation_estimand(recipe: RecipeName, group_scope: GroupScope) -> str:
         "passenger-group-disjoint prediction; surname categories may recur across "
         "folds when present in the selected recipe"
     )
+
+
+def configured_candidate_models(config: BenchmarkConfig) -> tuple[str, ...]:
+    if config.included_models is not None:
+        return config.included_models
+    if config.excluded_models:
+        excluded = set(config.excluded_models)
+        return tuple(
+            model for model in available_model_names() if model not in excluded
+        )
+    return tuple(model_names_for_profile(config.search_profile))
+
+
+def estimated_candidate_fit_upper_bound(config: BenchmarkConfig) -> int:
+    """Estimate tuned estimator fits, excluding fixed baseline audit fits."""
+    model_count = len(configured_candidate_models(config))
+    optimization_fits = 5 * config.n_iterations + 1
+    if config.selection_strategy in {"nested_cv", "repeated_cv"}:
+        selection_repeats = config.selection_cv_repeats
+        nested_folds = config.selection_cv_splits * selection_repeats
+        per_outer_run = (model_count * (1 + nested_folds) + 1) * optimization_fits
+    else:
+        per_outer_run = model_count * optimization_fits + 1
+    run_count = 1 if config.stage == "confirmation" else config.runs
+    return per_outer_run * run_count
 
 
 def relational_overlap_audit(
@@ -1038,6 +1066,12 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
     )
     parser.add_argument("--runs", type=int, default=3)
     parser.add_argument("--n-iterations", type=int, default=3)
+    parser.add_argument(
+        "--n-jobs",
+        type=int,
+        default=1,
+        help="Parallel worker count passed to supported estimators; use -1 for all CPUs.",
+    )
     parser.add_argument("--random-state", type=int, default=42)
     parser.add_argument("--holdout-size", type=float, default=0.2)
     parser.add_argument(
@@ -1118,6 +1152,8 @@ def main(argv: Sequence[str] | None = None) -> int:
         raise ValueError("--runs must be at least 1.")
     if args.n_iterations < 1:
         raise ValueError("--n-iterations must be at least 1.")
+    if args.n_jobs == 0 or args.n_jobs < -1:
+        raise ValueError("--n-jobs must be -1 or a positive integer.")
     if args.selection_cv_splits < 2:
         raise ValueError("--selection-cv-splits must be at least 2.")
     if args.selection_cv_repeats < 1:
@@ -1163,6 +1199,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         confirmation_seed=args.confirmation_seed,
         campaign_id=args.campaign_id,
         max_runtime_seconds=args.max_runtime_seconds,
+        n_jobs=args.n_jobs,
     )
 
     data_dir = ensure_competition_data(
@@ -1191,6 +1228,16 @@ def main(argv: Sequence[str] | None = None) -> int:
             "The reserved confirmation partition has already been evaluated for this "
             "campaign. Start a separately documented campaign instead of reusing it."
         )
+    estimated_candidate_fits = estimated_candidate_fit_upper_bound(config)
+    print(
+        (
+            "[benchmark] protocol: "
+            f"estimand={validation_estimand(config.recipe, config.group_scope)}; "
+            f"estimated candidate fit upper bound={estimated_candidate_fits}"
+        ),
+        file=sys.stderr,
+        flush=True,
+    )
 
     partitions = {
         "official_train_rows": len(train),
@@ -1249,6 +1296,7 @@ def main(argv: Sequence[str] | None = None) -> int:
             "validation_estimand": validation_estimand(
                 config.recipe, config.group_scope
             ),
+            "estimated_candidate_fit_upper_bound": estimated_candidate_fits,
             "development_interval": (
                 "Group bootstrap interval of recorded outer predictions; it "
                 "does not represent post-selection confirmation."
@@ -1361,6 +1409,7 @@ def _make_mamut(
         optimization_method=config.optimization_method,
         n_iterations=config.n_iterations,
         random_state=random_state,
+        n_jobs=config.n_jobs,
         exclude_models=list(config.excluded_models),
         include_models=(
             list(config.included_models) if config.included_models is not None else None

--- a/scripts/benchmark_kaggle.py
+++ b/scripts/benchmark_kaggle.py
@@ -734,21 +734,23 @@ def group_bootstrap_accuracy_interval(
     if predictions is None or predictions.empty:
         return np.nan, np.nan
     rng = np.random.default_rng(random_state)
-    frames = [frame for _, frame in predictions.groupby("repeat", sort=True)]
-    samples = []
+    grouped_repeats = []
+    for _, frame in predictions.groupby("repeat", sort=True):
+        grouped = (
+            frame.groupby("group", sort=False)["correct"]
+            .agg(["sum", "count"])
+            .to_numpy(dtype=float)
+        )
+        grouped_repeats.append(grouped)
+    samples = np.empty(n_resamples, dtype=float)
     for _ in range(n_resamples):
-        correctness = []
-        for frame in frames:
-            grouped = {
-                group: values["correct"].to_numpy(dtype=float)
-                for group, values in frame.groupby("group", sort=False)
-            }
-            group_names = list(grouped)
-            chosen = rng.choice(group_names, size=len(group_names), replace=True)
-            correctness.extend(
-                value for group in chosen for value in grouped[str(group)]
-            )
-        samples.append(float(np.mean(correctness)))
+        correct = 0.0
+        count = 0.0
+        for grouped in grouped_repeats:
+            selected = rng.integers(0, len(grouped), size=len(grouped))
+            correct += grouped[selected, 0].sum()
+            count += grouped[selected, 1].sum()
+        samples[_] = correct / count
     alpha = (1 - confidence_level) / 2
     return tuple(float(value) for value in np.quantile(samples, [alpha, 1 - alpha]))
 

--- a/tests/test_evidence.py
+++ b/tests/test_evidence.py
@@ -41,6 +41,19 @@ def test_detect_leakage_risks_flags_target_copy_and_target_like_name():
     assert "id_like_high_cardinality_feature" in set(checks["check"])
 
 
+def test_conflicting_duplicate_features_are_data_ambiguity_not_leakage_warning():
+    X = pd.DataFrame({"signal": [1, 1, 2], "segment": ["a", "a", "b"]})
+    y = pd.Series([0, 1, 1], name="target")
+
+    checks = detect_leakage_risks(X, y)
+    collision = checks.loc[
+        checks["check"].eq("duplicate_features_conflicting_targets")
+    ].iloc[0]
+
+    assert collision["severity"] == "info"
+    assert "not evidence of leakage" in collision["message"]
+
+
 def test_generate_evidence_contains_baselines_and_score_intervals():
     X, y = _classification_frame()
     mamut = Mamut(
@@ -103,6 +116,48 @@ def test_generate_evidence_uses_validation_when_holdout_is_absent():
     assert not bool(mamut.validation_integrity_.iloc[0]["holdout_available"])
 
 
+def test_final_confirmation_evidence_can_omit_non_selected_candidates():
+    X, y = _classification_frame()
+    mamut = Mamut(
+        include_models=["GaussianNB", "LogisticRegression"],
+        n_iterations=1,
+        optimization_method="random_search",
+        holdout_size=0.2,
+        evidence_cv_splits=2,
+        evidence_cv_repeats=1,
+    )
+    mamut.fit(X, y)
+
+    mamut.generate_evidence(dataset="holdout", include_candidate_comparison=False)
+
+    labels = set(mamut.baseline_comparison_["model"])
+    assert not any(label.startswith("MAMUT Candidate") for label in labels)
+    assert any(label.startswith("MAMUT Selected") for label in labels)
+
+
+def test_generate_evidence_reports_group_disjoint_validation():
+    X, y = _classification_frame()
+    groups = pd.Series(np.repeat(np.arange(36), 2))
+    mamut = Mamut(
+        exclude_models=_exclude_all_except("GaussianNB"),
+        n_iterations=1,
+        optimization_method="random_search",
+        random_state=42,
+        holdout_size=0.2,
+        evidence_cv_splits=2,
+        evidence_cv_repeats=1,
+        num_imputation="mean",
+    )
+    mamut.fit(X, y, groups=groups)
+
+    mamut.generate_evidence()
+    row = mamut.validation_integrity_.iloc[0]
+
+    assert bool(row["grouped_validation"])
+    assert row["cv_strategy"] == "RepeatedStratifiedGroupKFold"
+    assert row["evaluation_group_overlap"] == 0
+
+
 def test_selection_guidance_challenges_holdout_winner_without_silent_promotion():
     selected = "MAMUT Selected (GaussianNB)"
     baseline_comparison = pd.DataFrame(
@@ -144,7 +199,8 @@ def test_selection_guidance_challenges_holdout_winner_without_silent_promotion()
 
     row = guidance.iloc[0]
     assert row["status"] == "challenged"
-    assert row["recommended_model"] == "Random Forest"
+    assert row["recommended_model"] == selected
+    assert row["review_candidate"] == "Random Forest"
     assert "Do not silently promote" in row["action"]
 
 

--- a/tests/test_kaggle_benchmark.py
+++ b/tests/test_kaggle_benchmark.py
@@ -9,6 +9,8 @@ import scripts.benchmark_kaggle as benchmark_kaggle
 from scripts.benchmark_kaggle import (
     BenchmarkConfig,
     _coerce_bool_predictions,
+    _make_mamut,
+    estimated_candidate_fit_upper_bound,
     fit_submission_model,
     format_results,
     group_bootstrap_accuracy_interval,
@@ -136,6 +138,70 @@ def test_competition_v3_allows_target_free_batch_features_under_passenger_scope(
     assert "competition-aligned" in validation_estimand(
         "spaceship_competition_v3", "passenger"
     )
+
+
+def test_candidate_fit_estimate_makes_nested_search_cost_explicit():
+    fixed = BenchmarkConfig(
+        competition="spaceship-titanic",
+        recipe="spaceship_inductive_v2",
+        runs=5,
+        n_iterations=3,
+        random_state=42,
+        holdout_size=0.2,
+        validation_protocol="grouped",
+        score_metric="accuracy",
+        search_profile="balanced",
+        selection_strategy="single_split",
+        selection_cv_splits=3,
+        selection_cv_repeats=1,
+        selection_practical_margin=0.005,
+        preprocessing_profile="auto",
+        optimization_method="random_search",
+        excluded_models=(),
+        included_models=("LGBMClassifier",),
+    )
+    broad_nested = BenchmarkConfig(
+        **{
+            **fixed.__dict__,
+            "runs": 3,
+            "selection_strategy": "nested_cv",
+            "included_models": (
+                "RandomForestClassifier",
+                "ExtraTreesClassifier",
+                "LGBMClassifier",
+                "CatBoostClassifier",
+                "XGBClassifier",
+            ),
+        }
+    )
+
+    assert estimated_candidate_fit_upper_bound(fixed) == 85
+    assert estimated_candidate_fit_upper_bound(broad_nested) == 1008
+
+
+def test_benchmark_threads_are_forwarded_to_mamut():
+    config = BenchmarkConfig(
+        competition="spaceship-titanic",
+        recipe="spaceship_inductive_v2",
+        runs=1,
+        n_iterations=1,
+        random_state=42,
+        holdout_size=0.2,
+        validation_protocol="grouped",
+        score_metric="accuracy",
+        search_profile="quick",
+        selection_strategy="single_split",
+        selection_cv_splits=2,
+        selection_cv_repeats=1,
+        selection_practical_margin=0.005,
+        preprocessing_profile="auto",
+        optimization_method="random_search",
+        excluded_models=(),
+        included_models=("LGBMClassifier",),
+        n_jobs=-1,
+    )
+
+    assert _make_mamut(config, random_state=42, final_refit=True).n_jobs == -1
 
 
 def test_passenger_groups_are_derived_from_passenger_identifier_prefix():

--- a/tests/test_kaggle_benchmark.py
+++ b/tests/test_kaggle_benchmark.py
@@ -1,0 +1,397 @@
+import math
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+import scripts.benchmark_kaggle as benchmark_kaggle
+from scripts.benchmark_kaggle import (
+    BenchmarkConfig,
+    _coerce_bool_predictions,
+    format_results,
+    group_bootstrap_accuracy_interval,
+    household_components,
+    passenger_groups,
+    prepare_spaceship_features,
+    prepare_spaceship_modeling_split,
+    reserve_confirmation_partition,
+    run_confirmation_benchmark,
+    split_spaceship_validation,
+    summarize_runs,
+    validate_recipe_scope,
+    write_submission,
+)
+
+
+def _spaceship_train() -> pd.DataFrame:
+    return pd.DataFrame(
+        {
+            "PassengerId": ["0001_01", "0002_01", "0003_01", "0003_02"],
+            "HomePlanet": ["Europa", "Earth", "Mars", "Mars"],
+            "CryoSleep": [False, True, False, False],
+            "Cabin": ["B/0/P", "F/1/S", "A/2/S", None],
+            "Destination": [
+                "TRAPPIST-1e",
+                "TRAPPIST-1e",
+                "55 Cancri e",
+                "PSO J318.5-22",
+            ],
+            "Age": [39.0, 24.0, 58.0, 33.0],
+            "VIP": [False, False, True, False],
+            "RoomService": [0.0, 109.0, 43.0, None],
+            "FoodCourt": [0.0, 9.0, 3576.0, 0.0],
+            "ShoppingMall": [0.0, 25.0, 0.0, 0.0],
+            "Spa": [0.0, 549.0, 6715.0, 0.0],
+            "VRDeck": [0.0, 44.0, 49.0, 0.0],
+            "Name": ["A B", "C D", "E F", "G H"],
+            "Transported": [False, True, False, True],
+        }
+    )
+
+
+def _spaceship_test() -> pd.DataFrame:
+    return (
+        _spaceship_train()
+        .drop(columns=["Transported"])
+        .assign(PassengerId=["9001_01", "9002_01", "9003_01", "9003_02"])
+    )
+
+
+def test_spaceship_basic_recipe_creates_expected_feature_contract():
+    X, y, X_test, passenger_ids = prepare_spaceship_features(
+        _spaceship_train(),
+        _spaceship_test(),
+        recipe="spaceship_basic",
+    )
+
+    assert list(X.columns) == list(X_test.columns)
+    assert len(X) == len(y) == 4
+    assert passenger_ids.tolist() == ["9001_01", "9002_01", "9003_01", "9003_02"]
+    assert {
+        "PassengerNumber",
+        "PassengerGroupSize",
+        "PassengerGroupIsSolo",
+        "CabinDeck",
+        "CabinNumber",
+        "CabinSide",
+    }.issubset(X.columns)
+    assert {"SpendingTotal", "SpendingAny", "SpendingMissingCount"}.issubset(X.columns)
+    assert {"PassengerId", "PassengerGroup", "Name", "Cabin", "Transported"}.isdisjoint(
+        X.columns
+    )
+    assert y.dtype == bool
+
+
+def test_spaceship_inductive_recipe_excludes_batch_cohort_features():
+    X, _, X_test, _ = prepare_spaceship_features(
+        _spaceship_train(),
+        _spaceship_test(),
+        recipe="spaceship_inductive",
+    )
+
+    assert list(X.columns) == list(X_test.columns)
+    assert "PassengerNumber" in X.columns
+    assert "PassengerGroupSize" not in X.columns
+    assert "PassengerGroupIsSolo" not in X.columns
+
+
+def test_spaceship_v2_recipes_add_domain_features_and_separate_batch_features():
+    inductive, _, _, _ = prepare_spaceship_features(
+        _spaceship_train(), _spaceship_test(), recipe="spaceship_inductive_v2"
+    )
+    cohort, _, _, _ = prepare_spaceship_features(
+        _spaceship_train(), _spaceship_test(), recipe="spaceship_cohort_v2"
+    )
+
+    assert {
+        "FamilyName",
+        "AgeBand",
+        "NoSpend",
+        "AmenitiesUsed",
+        "CryoSpendConflict",
+        "CabinNumberBand",
+    }.issubset(inductive.columns)
+    assert {"FamilyBatchSize", "FamilyBatchShared"}.isdisjoint(inductive.columns)
+    assert {"FamilyBatchSize", "FamilyBatchShared"}.issubset(cohort.columns)
+
+
+def test_cohort_v2_requires_household_component_scope():
+    with pytest.raises(ValueError, match="household_component"):
+        validate_recipe_scope("spaceship_cohort_v2", "passenger")
+
+
+def test_passenger_groups_are_derived_from_passenger_identifier_prefix():
+    groups = passenger_groups(_spaceship_train())
+
+    assert groups.tolist() == ["0001", "0002", "0003", "0003"]
+
+
+def test_household_components_join_distinct_passenger_groups_with_family_name():
+    frame = _spaceship_train().copy()
+    frame.loc[0, "Name"] = "A Shared"
+    frame.loc[1, "Name"] = "B Shared"
+
+    groups = household_components(frame)
+
+    assert groups.iloc[0] == groups.iloc[1]
+    assert groups.iloc[0] != groups.iloc[2]
+
+
+def test_grouped_validation_protocol_has_no_passenger_group_overlap():
+    modeling, holdout, modeling_groups, holdout_groups = split_spaceship_validation(
+        _spaceship_train(),
+        validation_protocol="grouped",
+        holdout_size=0.5,
+        random_state=42,
+    )
+
+    assert len(modeling) + len(holdout) == len(_spaceship_train())
+    assert set(modeling_groups).isdisjoint(holdout_groups)
+
+
+def test_reserved_confirmation_partition_is_group_disjoint():
+    development, confirmation, development_groups, confirmation_groups = (
+        reserve_confirmation_partition(
+            _spaceship_train(),
+            validation_protocol="grouped",
+            group_scope="passenger",
+            confirmation_size=0.5,
+            confirmation_seed=123,
+        )
+    )
+
+    assert len(development) + len(confirmation) == len(_spaceship_train())
+    assert set(development_groups).isdisjoint(confirmation_groups)
+
+
+def test_confirmation_scores_only_selected_prediction_without_passing_holdout_to_fit(
+    monkeypatch,
+):
+    captured = {}
+
+    class DummyModel:
+        random_state = 42
+        selected_estimator_ = type("ChosenEstimator", (), {})()
+        selection_summary_ = pd.DataFrame([{"model": "ChosenEstimator"}])
+        binary = True
+        score_metric_name = "accuracy_score"
+
+        @staticmethod
+        def score_metric(y_true, y_pred):
+            return float((pd.Series(y_true).to_numpy() == y_pred).mean())
+
+        def fit(self, X, y, **kwargs):
+            captured.update(kwargs)
+
+        @staticmethod
+        def predict(X):
+            return [True] * len(X)
+
+    monkeypatch.setattr(
+        benchmark_kaggle,
+        "_make_mamut",
+        lambda config, random_state, final_refit: DummyModel(),
+    )
+    monkeypatch.setattr(
+        benchmark_kaggle,
+        "benchmark_integrity_audit",
+        lambda *args, **kwargs: (
+            pd.DataFrame([{"model": "Random Forest", "score": 0.5}]),
+            pd.DataFrame([{"severity": "pass"}]),
+            0.0,
+        ),
+    )
+    config = BenchmarkConfig(
+        competition="spaceship-titanic",
+        recipe="spaceship_inductive_v2",
+        runs=1,
+        n_iterations=1,
+        random_state=42,
+        holdout_size=0.5,
+        validation_protocol="grouped",
+        score_metric="accuracy",
+        search_profile="quick",
+        selection_strategy="nested_cv",
+        selection_cv_splits=2,
+        selection_cv_repeats=1,
+        selection_practical_margin=0.005,
+        preprocessing_profile="auto",
+        optimization_method="random_search",
+        excluded_models=(),
+    )
+    development = _spaceship_train().iloc[:2]
+    confirmation = _spaceship_train().iloc[2:]
+
+    run_confirmation_benchmark(
+        development,
+        confirmation,
+        pd.Series(["0001", "0002"]),
+        pd.Series(["0003", "0003"]),
+        config=config,
+    )
+
+    assert "X_holdout" not in captured
+    assert "y_holdout" not in captured
+    assert "groups_holdout" not in captured
+
+
+def test_raw_recipe_preserves_original_feature_columns_without_target():
+    X, y, X_test, _ = prepare_spaceship_features(
+        _spaceship_train(),
+        _spaceship_test(),
+        recipe="raw",
+    )
+
+    assert "Transported" not in X.columns
+    assert "PassengerId" in X.columns
+    assert list(X.columns) == list(X_test.columns)
+    assert y.tolist() == [False, True, False, True]
+
+
+def test_modeling_split_prepares_features_after_outer_split():
+    modeling = _spaceship_train().iloc[:3]
+    holdout = _spaceship_train().iloc[3:]
+
+    X_modeling, y_modeling, X_holdout, y_holdout = prepare_spaceship_modeling_split(
+        modeling,
+        holdout,
+        recipe="spaceship_basic",
+    )
+
+    assert list(X_modeling.columns) == list(X_holdout.columns)
+    assert len(X_modeling) == len(y_modeling) == 3
+    assert len(X_holdout) == len(y_holdout) == 1
+    assert "Transported" not in X_modeling.columns
+
+
+def test_summarize_runs_tracks_score_stability_and_audit_candidate_delta():
+    runs = pd.DataFrame(
+        [
+            {
+                "selected_holdout_score": 0.80,
+                "audit_candidate_delta": 0.00,
+                "baseline_uplift": 0.05,
+                "guidance_status": "confirmed",
+                "duration_seconds": 1.0,
+            },
+            {
+                "selected_holdout_score": 0.82,
+                "audit_candidate_delta": 0.02,
+                "baseline_uplift": 0.03,
+                "guidance_status": "challenged",
+                "duration_seconds": 2.0,
+            },
+        ]
+    )
+
+    summary = summarize_runs(runs, score_column="selected_holdout_score")
+
+    assert summary["runs"] == 2
+    assert summary["mean_score"] == 0.81
+    assert summary["mean_audit_candidate_delta"] == 0.01
+    assert math.isclose(summary["p90_audit_candidate_delta"], 0.018)
+    assert summary["challenged_rate"] == 0.5
+    assert summary["stability_low"] == 0.80
+    assert summary["stability_high"] == 0.82
+
+
+def test_group_bootstrap_accuracy_interval_uses_recorded_group_predictions():
+    predictions = pd.DataFrame(
+        {
+            "repeat": [0, 0, 0, 0],
+            "group": ["a", "a", "b", "b"],
+            "correct": [True, True, False, False],
+        }
+    )
+
+    low, high = group_bootstrap_accuracy_interval(
+        predictions, random_state=42, n_resamples=200
+    )
+
+    assert 0 <= low <= 0.5 <= high <= 1
+
+
+def test_write_submission_matches_kaggle_schema(tmp_path: Path):
+    submission = pd.DataFrame(
+        {
+            "PassengerId": ["9001_01", "9002_01"],
+            "Transported": [True, False],
+        }
+    )
+
+    path = write_submission(submission, tmp_path / "submission.csv")
+
+    reloaded = pd.read_csv(path)
+    assert list(reloaded.columns) == ["PassengerId", "Transported"]
+    assert reloaded["PassengerId"].tolist() == ["9001_01", "9002_01"]
+    assert reloaded["Transported"].tolist() == [True, False]
+
+
+def test_format_results_markdown_contains_aggregate_and_run_tables():
+    config = BenchmarkConfig(
+        competition="spaceship-titanic",
+        recipe="spaceship_basic",
+        runs=1,
+        n_iterations=1,
+        random_state=42,
+        holdout_size=0.2,
+        validation_protocol="grouped",
+        score_metric="accuracy",
+        search_profile="quick",
+        selection_strategy="single_split",
+        selection_cv_splits=5,
+        selection_cv_repeats=2,
+        selection_practical_margin=0.005,
+        preprocessing_profile="auto",
+        optimization_method="random_search",
+        excluded_models=("SVC",),
+    )
+    payload = {
+        "metadata": {},
+        "config": config.__dict__,
+        "aggregate": {
+            "runs": 1,
+            "mean_score": 0.81234,
+            "group_bootstrap_low": 0.74123,
+        },
+        "runs": [
+            {
+                "run": 0,
+                "selected_model": "XGBClassifier",
+                "selected_holdout_score": 0.81234,
+            }
+        ],
+    }
+
+    output = format_results(payload, "markdown")
+
+    assert "## Aggregate" in output
+    assert "## Runs" in output
+    assert "XGBClassifier" in output
+    assert "0.8123" in output
+    assert "0.7412" in output
+
+
+def test_format_results_json_converts_nan_to_null():
+    payload = {
+        "metadata": {},
+        "config": {},
+        "aggregate": {"runs": 1, "mean_score": float("nan")},
+        "runs": [{"run": 0, "baseline_uplift": float("nan")}],
+    }
+
+    output = format_results(payload, "json")
+
+    assert '"mean_score": null' in output
+    assert '"baseline_uplift": null' in output
+
+
+def test_bool_prediction_coercion_for_submission_output():
+    assert _coerce_bool_predictions([True, False, "True", "false", 1, 0]) == [
+        True,
+        False,
+        True,
+        False,
+        True,
+        False,
+    ]

--- a/tests/test_kaggle_benchmark.py
+++ b/tests/test_kaggle_benchmark.py
@@ -3,11 +3,13 @@ from pathlib import Path
 
 import pandas as pd
 import pytest
+from sklearn.dummy import DummyClassifier
 
 import scripts.benchmark_kaggle as benchmark_kaggle
 from scripts.benchmark_kaggle import (
     BenchmarkConfig,
     _coerce_bool_predictions,
+    fit_submission_model,
     format_results,
     group_bootstrap_accuracy_interval,
     household_components,
@@ -264,6 +266,52 @@ def test_confirmation_scores_only_selected_prediction_without_passing_holdout_to
     assert "X_holdout" not in captured
     assert "y_holdout" not in captured
     assert "groups_holdout" not in captured
+
+
+def test_submission_refits_frozen_confirmation_parameters_without_retuning(
+    monkeypatch,
+):
+    class FrozenModel:
+        selected_estimator_ = DummyClassifier(strategy="most_frequent")
+
+        @staticmethod
+        def _make_model_preprocessor(model_name):
+            return None
+
+    monkeypatch.setattr(
+        benchmark_kaggle,
+        "_make_mamut",
+        lambda *args, **kwargs: pytest.fail("Frozen submission must not retune MAMUT."),
+    )
+    config = BenchmarkConfig(
+        competition="spaceship-titanic",
+        recipe="spaceship_inductive_v2",
+        runs=1,
+        n_iterations=1,
+        random_state=42,
+        holdout_size=0.5,
+        validation_protocol="grouped",
+        score_metric="accuracy",
+        search_profile="quick",
+        selection_strategy="single_split",
+        selection_cv_splits=2,
+        selection_cv_repeats=1,
+        selection_practical_margin=0.005,
+        preprocessing_profile="auto",
+        optimization_method="random_search",
+        excluded_models=(),
+    )
+
+    submission, returned_model = fit_submission_model(
+        _spaceship_train(),
+        _spaceship_test(),
+        config=config,
+        frozen_model=FrozenModel(),
+    )
+
+    assert list(submission.columns) == ["PassengerId", "Transported"]
+    assert len(submission) == len(_spaceship_test())
+    assert isinstance(returned_model, FrozenModel)
 
 
 def test_raw_recipe_preserves_original_feature_columns_without_target():

--- a/tests/test_kaggle_benchmark.py
+++ b/tests/test_kaggle_benchmark.py
@@ -14,11 +14,13 @@ from scripts.benchmark_kaggle import (
     passenger_groups,
     prepare_spaceship_features,
     prepare_spaceship_modeling_split,
+    relational_overlap_audit,
     reserve_confirmation_partition,
     run_confirmation_benchmark,
     split_spaceship_validation,
     summarize_runs,
     validate_recipe_scope,
+    validation_estimand,
     write_submission,
 )
 
@@ -120,6 +122,20 @@ def test_cohort_v2_requires_household_component_scope():
         validate_recipe_scope("spaceship_cohort_v2", "passenger")
 
 
+def test_competition_v3_allows_target_free_batch_features_under_passenger_scope():
+    validate_recipe_scope("spaceship_competition_v3", "passenger")
+    features, _, _, _ = prepare_spaceship_features(
+        _spaceship_train(), _spaceship_test(), recipe="spaceship_competition_v3"
+    )
+
+    assert {"PassengerGroupSize", "FamilyBatchSize", "FamilyBatchShared"}.issubset(
+        features.columns
+    )
+    assert "competition-aligned" in validation_estimand(
+        "spaceship_competition_v3", "passenger"
+    )
+
+
 def test_passenger_groups_are_derived_from_passenger_identifier_prefix():
     groups = passenger_groups(_spaceship_train())
 
@@ -162,6 +178,21 @@ def test_reserved_confirmation_partition_is_group_disjoint():
 
     assert len(development) + len(confirmation) == len(_spaceship_train())
     assert set(development_groups).isdisjoint(confirmation_groups)
+
+
+def test_relational_overlap_audit_reports_recurring_family_names_separately():
+    modeling = _spaceship_train().iloc[:2].copy()
+    evaluation = _spaceship_train().iloc[2:].copy()
+    modeling.loc[0, "Name"] = "A Shared"
+    evaluation.loc[0, "Name"] = "B Shared"
+
+    rows = pd.DataFrame(relational_overlap_audit(modeling, evaluation)).set_index(
+        "feature"
+    )
+
+    assert rows.loc["PassengerGroup", "shared_values"] == 0
+    assert rows.loc["FamilyName", "shared_values"] == 1
+    assert rows.loc["FamilyName", "evaluation_rows_with_seen_value"] == 1
 
 
 def test_confirmation_scores_only_selected_prediction_without_passing_holdout_to_fit(

--- a/tests/test_ml_smoke.py
+++ b/tests/test_ml_smoke.py
@@ -1,5 +1,6 @@
 import numpy as np
 import pandas as pd
+import pytest
 from sklearn.metrics import (
     accuracy_score,
     balanced_accuracy_score,
@@ -30,6 +31,28 @@ SMALL_XGBOOST_SEARCH = {
     "tree_method": (["hist"], "categorical"),
     "n_jobs": ([1], "categorical"),
     "verbosity": ([0], "categorical"),
+}
+
+SMALL_LIGHTGBM_SEARCH = {
+    "n_estimators": (5, 8, "int"),
+    "learning_rate": (0.05, 0.20, "float"),
+    "num_leaves": (7, 15, "int"),
+    "max_depth": ([3, 5], "categorical"),
+    "min_child_samples": (5, 10, "int"),
+    "subsample": (0.8, 1.0, "float"),
+    "colsample_bytree": (0.8, 1.0, "float"),
+    "reg_alpha": (1e-6, 1e-3, "log"),
+    "reg_lambda": (1.0, 2.0, "float"),
+    "class_weight": ([None], "categorical"),
+}
+
+SMALL_CATBOOST_SEARCH = {
+    "iterations": (5, 8, "int"),
+    "learning_rate": (0.05, 0.20, "float"),
+    "depth": (2, 3, "int"),
+    "l2_leaf_reg": (1.0, 3.0, "float"),
+    "random_strength": (1e-3, 1e-2, "log"),
+    "border_count": (32, 64, "int"),
 }
 
 
@@ -131,7 +154,8 @@ def test_mamut_predict_tolerates_unseen_categories(tmp_path, monkeypatch):
     X_new = X.head(4).copy()
     X_new["segment"] = "never_seen"
 
-    predictions = mamut.predict(X_new)
+    with pytest.warns(UserWarning, match="Found unknown categories"):
+        predictions = mamut.predict(X_new)
 
     assert predictions.shape == (4,)
     assert set(predictions).issubset({"yes", "no"})
@@ -159,6 +183,34 @@ def test_mamut_xgboost_smoke(tmp_path, monkeypatch):
     assert predictions.shape == (8,)
 
 
+def test_mamut_lightgbm_and_catboost_smoke(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setitem(
+        model_selection.model_param_dict,
+        "LGBMClassifier",
+        SMALL_LIGHTGBM_SEARCH,
+    )
+    monkeypatch.setitem(
+        model_selection.model_param_dict,
+        "CatBoostClassifier",
+        SMALL_CATBOOST_SEARCH,
+    )
+    X, y = _numeric_classification_frame()
+    mamut = Mamut(
+        include_models=["LGBMClassifier", "CatBoostClassifier"],
+        n_iterations=1,
+        optimization_method="random_search",
+        random_state=42,
+        n_jobs=1,
+    )
+
+    mamut.fit(X, y)
+    predictions = mamut.predict(X.head(8))
+
+    assert {"LGBMClassifier", "CatBoostClassifier"}.issubset(mamut.raw_fitted_models_)
+    assert predictions.shape == (8,)
+
+
 def test_mamut_can_refit_selected_model_on_modeling_data(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
     X, y = _numeric_classification_frame()
@@ -177,6 +229,33 @@ def test_mamut_can_refit_selected_model_on_modeling_data(tmp_path, monkeypatch):
     assert mamut.final_preprocessor_ is not None
     assert mamut.holdout_score_ is not None
     assert mamut.predict(X.head(6)).shape == (6,)
+
+
+def test_mamut_nested_cv_selection_records_selection_summary(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    X, y = _mixed_classification_frame()
+    mamut = Mamut(
+        include_models=["GaussianNB"],
+        selection_strategy="nested_cv",
+        selection_cv_splits=2,
+        selection_cv_repeats=1,
+        holdout_size=0.2,
+        refit_final_model=True,
+        n_iterations=1,
+        optimization_method="random_search",
+        random_state=42,
+        num_imputation="mean",
+        cat_imputation="most_frequent",
+    )
+
+    mamut.fit(X, y)
+
+    assert mamut.selection_summary_ is not None
+    assert mamut.selection_summary_.iloc[0]["selection_strategy"] == "nested_cv"
+    assert bool(mamut.selection_summary_.iloc[0]["selected"])
+    assert mamut.final_estimator_ is mamut.selected_estimator_
+    assert mamut.holdout_score_ is not None
+    assert mamut.best_model_.predict(X.head(4)).shape == (4,)
 
 
 def test_public_ensemble_predictions_use_original_labels(tmp_path, monkeypatch):
@@ -200,6 +279,36 @@ def test_public_ensemble_predictions_use_original_labels(tmp_path, monkeypatch):
 
     assert set(ensemble.predict(X.head(6))).issubset({"yes", "no"})
     assert set(greedy_ensemble.predict(X.head(6))).issubset({"yes", "no"})
+
+
+def test_public_ensemble_preserves_model_specific_preprocessing(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setitem(
+        model_selection.model_param_dict,
+        "LGBMClassifier",
+        SMALL_LIGHTGBM_SEARCH,
+    )
+    X, y = _mixed_classification_frame()
+    mamut = Mamut(
+        include_models=["GaussianNB", "LGBMClassifier"],
+        n_iterations=1,
+        optimization_method="random_search",
+        random_state=42,
+        n_jobs=1,
+        num_imputation="mean",
+        cat_imputation="most_frequent",
+    )
+    mamut.fit(X, y)
+
+    ensemble = mamut.create_ensemble()
+    fitted_estimators = ensemble.named_steps["model"].estimator.named_estimators_
+
+    assert fitted_estimators["GaussianNB"].preprocessor_.profile == "generic_ohe"
+    assert (
+        fitted_estimators["LGBMClassifier"].preprocessor_.profile
+        == "native_categorical"
+    )
+    assert ensemble.predict(X.head(4)).shape == (4,)
 
 
 def test_mamut_evaluate_uses_holdout_when_available(tmp_path, monkeypatch):

--- a/tests/test_model_selection_registry.py
+++ b/tests/test_model_selection_registry.py
@@ -1,0 +1,147 @@
+import numpy as np
+import pandas as pd
+from sklearn.linear_model import LogisticRegression
+
+from mamut.model_selection import (
+    ModelSelector,
+    available_model_names,
+    preprocessing_profile_for_model,
+    select_from_repeated_cv_summary,
+)
+from mamut.utils.utils import (
+    adjust_search_spaces,
+    model_names_for_profile,
+    model_param_dict,
+)
+
+
+def test_search_profiles_select_expected_candidate_sets():
+    assert model_names_for_profile("quick") == (
+        "LogisticRegression",
+        "RandomForestClassifier",
+        "ExtraTreesClassifier",
+        "GaussianNB",
+    )
+    assert "CatBoostClassifier" in model_names_for_profile("balanced")
+    assert set(model_names_for_profile("thorough")) == set(available_model_names())
+
+
+def test_random_forest_search_space_uses_leaf_counts_not_large_fractions():
+    low, high, distribution = model_param_dict["RandomForestClassifier"][
+        "min_samples_leaf"
+    ]
+
+    assert distribution == "int"
+    assert low == 1
+    assert high <= 20
+
+
+def test_logistic_non_elasticnet_configuration_omits_l1_ratio():
+    configured = adjust_search_spaces(
+        {"solver": "lbfgs", "l1_ratio": 0.5},
+        LogisticRegression(),
+    )
+
+    assert configured["penalty"] == "l2"
+    assert "l1_ratio" not in configured
+
+
+def test_boosted_native_models_use_native_categorical_preprocessing_profiles():
+    assert preprocessing_profile_for_model("CatBoostClassifier") == "native_categorical"
+    assert preprocessing_profile_for_model("LGBMClassifier") == "native_categorical"
+    assert preprocessing_profile_for_model("RandomForestClassifier") == "tree_ohe"
+
+
+def test_include_models_takes_precedence_over_search_profile():
+    selected = ModelSelector._resolve_model_names(
+        include_models=["KNeighborsClassifier"],
+        exclude_models=None,
+        search_profile="quick",
+    )
+
+    assert selected == ["KNeighborsClassifier"]
+
+
+def test_exclude_models_preserves_backward_compatible_all_model_pool():
+    selected = ModelSelector._resolve_model_names(
+        include_models=None,
+        exclude_models=[
+            name for name in available_model_names() if name != "KNeighborsClassifier"
+        ],
+        search_profile="quick",
+    )
+
+    assert selected == ["KNeighborsClassifier"]
+
+
+def test_model_selector_fits_preprocessing_inside_each_cv_fold(monkeypatch):
+    instances = []
+
+    class RecordingPreprocessor:
+        def __init__(self):
+            self.fit_index = None
+            self.transform_index = None
+            instances.append(self)
+
+        def fit_transform(self, X, y):
+            self.fit_index = set(X.index)
+            return X[["signal"]].to_numpy(), np.asarray(y)
+
+        def transform(self, X):
+            self.transform_index = set(X.index)
+            return X[["signal"]].to_numpy()
+
+    X = pd.DataFrame({"signal": np.arange(20), "noise": np.arange(20) % 3})
+    y = pd.Series([0, 1] * 10)
+    monkeypatch.setitem(
+        model_param_dict,
+        "GaussianNB",
+        {"var_smoothing": (1e-9, 1e-9, "log")},
+    )
+    selector = ModelSelector(
+        X.to_numpy(),
+        y.to_numpy(),
+        X.to_numpy(),
+        y.to_numpy(),
+        score_metric=lambda y_true, y_pred: float(np.mean(y_true == y_pred)),
+        X_train_raw=X,
+        y_train_raw=y,
+        preprocessor_factory=RecordingPreprocessor,
+        include_models=["GaussianNB"],
+        optimization_method="random_search",
+        n_iterations=1,
+        random_state=42,
+    )
+
+    selector.optimize_model(selector.models[0])
+
+    assert len(instances) == 5
+    assert all(
+        instance.fit_index.isdisjoint(instance.transform_index)
+        for instance in instances
+    )
+
+
+def test_repeated_cv_selection_prefers_lower_variance_inside_practical_tie():
+    summary = pd.DataFrame(
+        [
+            {
+                "model": "HighMean",
+                "mean_score": 0.812,
+                "std_score": 0.040,
+                "selection_duration": 1.0,
+                "status": "ok",
+            },
+            {
+                "model": "StableTie",
+                "mean_score": 0.810,
+                "std_score": 0.010,
+                "selection_duration": 2.0,
+                "status": "ok",
+            },
+        ]
+    )
+
+    selected = select_from_repeated_cv_summary(summary, practical_margin=0.005)
+
+    assert selected == "StableTie"

--- a/tests/test_preprocessing.py
+++ b/tests/test_preprocessing.py
@@ -38,3 +38,40 @@ def test_fit_transform_resets_inferred_feature_state(binary_y):
 
     assert prp.numeric_features == ["num_b"]
     assert prp.categorical_features == ["cat_b"]
+
+
+def test_tree_ohe_profile_skips_numeric_scaling_and_keeps_numpy_output(X, binary_y):
+    prp = Preprocessor(profile="tree_ohe")
+
+    Xft, _ = prp.fit_transform(X, binary_y)
+
+    assert isinstance(Xft, np.ndarray)
+    assert prp.scaler_ is None
+    assert "category_encoding" in prp.report()
+
+
+def test_native_categorical_profile_preserves_dataframe_categories(X, binary_y):
+    X = X.copy()
+    X.loc[0, "cat1"] = np.nan
+    prp = Preprocessor(profile="native_categorical")
+
+    Xft, _ = prp.fit_transform(X, binary_y)
+    Xt = prp.transform(X.head())
+
+    assert isinstance(Xft, pd.DataFrame)
+    assert isinstance(Xt, pd.DataFrame)
+    assert str(Xft["cat1"].dtype) == "category"
+    assert prp.missing_num_trans_ is None
+    assert prp.scaler_ is None
+
+
+def test_transform_imputes_missing_values_not_seen_during_fit():
+    X_train = pd.DataFrame({"value": [1.0, 2.0, 3.0], "kind": ["a", "b", "a"]})
+    X_new = pd.DataFrame({"value": [np.nan], "kind": [np.nan]})
+    y_train = pd.Series([0, 1, 0])
+    prp = Preprocessor(num_imputation="mean", cat_imputation="most_frequent")
+
+    prp.fit_transform(X_train, y_train)
+    transformed = prp.transform(X_new)
+
+    assert np.isfinite(transformed).all()

--- a/tests/test_wrapper.py
+++ b/tests/test_wrapper.py
@@ -1,4 +1,5 @@
 import numpy as np
+import pandas as pd
 import pytest
 
 from mamut.wrapper import Mamut
@@ -12,6 +13,7 @@ def test_wrapper_binary_target(X, binary_y):
 
     assert mamut.best_score_ is not None
     assert isinstance(pred, np.ndarray)
+    assert pred.ndim == 1
 
 
 def test_wrapper_multiclass_target(X, multiclass_y):
@@ -21,6 +23,7 @@ def test_wrapper_multiclass_target(X, multiclass_y):
 
     assert mamut.best_score_ is not None
     assert isinstance(pred, np.ndarray)
+    assert pred.ndim == 1
 
 
 def test_wrapper_imbalanced_target(X, imbalanced_y):
@@ -103,6 +106,30 @@ def test_wrapper_explicit_holdout_is_not_used_as_validation(X, binary_y):
     assert mamut.X_holdout_raw_.equals(X_holdout)
 
 
+def test_wrapper_grouped_holdout_and_validation_are_group_disjoint(X, binary_y):
+    groups = np.repeat(np.arange(50), 2)
+    mamut = Mamut(n_iterations=1, holdout_size=0.2)
+
+    mamut.fit(X, binary_y, groups=groups)
+
+    assert set(mamut.groups_modeling_).isdisjoint(mamut.groups_holdout_)
+    assert set(mamut.groups_train_).isdisjoint(mamut.groups_validation_)
+
+
+def test_wrapper_rejects_overlapping_explicit_holdout_groups(X, binary_y):
+    mamut = Mamut(n_iterations=1)
+
+    with pytest.raises(ValueError, match="overlap modeling groups"):
+        mamut.fit(
+            X.iloc[:80],
+            binary_y.iloc[:80],
+            X_holdout=X.iloc[80:],
+            y_holdout=binary_y.iloc[80:],
+            groups=pd.Series(np.arange(80)),
+            groups_holdout=pd.Series([79, *range(81, 100)]),
+        )
+
+
 def test_wrapper_rejects_invalid_configuration():
     with pytest.raises(ValueError, match="score_metric"):
         Mamut(score_metric="bad")
@@ -112,3 +139,19 @@ def test_wrapper_rejects_invalid_configuration():
         Mamut(n_iterations=0)
     with pytest.raises(ValueError, match="unsupported model"):
         Mamut(exclude_models=["NoSuchModel"])
+    with pytest.raises(ValueError, match="include_models"):
+        Mamut(include_models=["GaussianNB"], exclude_models=["LogisticRegression"])
+    with pytest.raises(ValueError, match="search_profile"):
+        Mamut(search_profile="huge")
+    with pytest.raises(ValueError, match="n_jobs"):
+        Mamut(n_jobs=0)
+    with pytest.raises(ValueError, match="selection_strategy"):
+        Mamut(selection_strategy="holdout")
+    with pytest.raises(ValueError, match="selection_cv_splits"):
+        Mamut(selection_cv_splits=1)
+    with pytest.raises(ValueError, match="selection_cv_repeats"):
+        Mamut(selection_cv_repeats=0)
+    with pytest.raises(ValueError, match="selection_practical_margin"):
+        Mamut(selection_practical_margin=-0.1)
+    with pytest.raises(ValueError, match="preprocessing_profile"):
+        Mamut(preprocessing_profile="native")

--- a/uv.lock
+++ b/uv.lock
@@ -101,6 +101,27 @@ filecache = [
 ]
 
 [[package]]
+name = "catboost"
+version = "1.2.10"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "graphviz" },
+    { name = "matplotlib" },
+    { name = "numpy" },
+    { name = "pandas" },
+    { name = "plotly" },
+    { name = "scipy" },
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e9/0e/09e8fa0858570fda88090bc3f441b69c18ea3d6f4a02fd41aa5426c157bf/catboost-1.2.10.tar.gz", hash = "sha256:26ae6d423acaf0e9d8160f2477a990431057ed04522d993c2f42dac62743b4f7", size = 39925863, upload-time = "2026-02-18T16:13:29.092Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bb/52/f5cd568800c87576012d715481730da93bcc34e609c5c204550a9ad0c067/catboost-1.2.10-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:b27115d5b443048f710001c8ac666892dfe03498492310b00466203c91cc30a5", size = 28884278, upload-time = "2026-02-18T16:12:07.659Z" },
+    { url = "https://files.pythonhosted.org/packages/33/ae/d33a8feba68fa810b30d70c660e4a2c62299472c2e1aa34406ccce306d13/catboost-1.2.10-cp312-cp312-manylinux2014_aarch64.whl", hash = "sha256:39234b3692b6c9002b4a2ac529025fc210dd72feb9b621b27d17c65b7d3e9f92", size = 96704178, upload-time = "2026-02-18T16:12:11.229Z" },
+    { url = "https://files.pythonhosted.org/packages/15/6c/08eabe522ac5cefc605ef81f273d77602130739ec7bcdc0ef192aa0a1f07/catboost-1.2.10-cp312-cp312-manylinux2014_x86_64.whl", hash = "sha256:b28f763776e62f50da90dddf73b36399583295032667a7e46fc5c1f2593eb80f", size = 97136498, upload-time = "2026-02-18T16:12:15.339Z" },
+    { url = "https://files.pythonhosted.org/packages/93/e2/f467a133b37eef2b3d8697d46a6e7f0da24bd3643f5475817c473ffc41dc/catboost-1.2.10-cp312-cp312-win_amd64.whl", hash = "sha256:6b8a7ef11d7a89fc547760cfafeee895011a4b92cc1f60d00235ef80a71158ed", size = 100214655, upload-time = "2026-02-18T16:12:20.046Z" },
+]
+
+[[package]]
 name = "certifi"
 version = "2026.4.22"
 source = { registry = "https://pypi.org/simple" }
@@ -369,6 +390,15 @@ wheels = [
 ]
 
 [[package]]
+name = "graphviz"
+version = "0.21"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f8/b3/3ac91e9be6b761a4b30d66ff165e54439dcd48b83f4e20d644867215f6ca/graphviz-0.21.tar.gz", hash = "sha256:20743e7183be82aaaa8ad6c93f8893c923bd6658a04c32ee115edb3c8a835f78", size = 200434, upload-time = "2025-06-15T09:35:05.824Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/91/4c/e0ce1ef95d4000ebc1c11801f9b944fa5910ecc15b5e351865763d8657f8/graphviz-0.21-py3-none-any.whl", hash = "sha256:54f33de9f4f911d7e84e4191749cac8cc5653f815b06738c54db9a15ab8b1e42", size = 47300, upload-time = "2025-06-15T09:35:04.433Z" },
+]
+
+[[package]]
 name = "greenlet"
 version = "3.5.0"
 source = { registry = "https://pypi.org/simple" }
@@ -634,6 +664,23 @@ wheels = [
 ]
 
 [[package]]
+name = "lightgbm"
+version = "4.6.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+    { name = "scipy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/68/0b/a2e9f5c5da7ef047cc60cef37f86185088845e8433e54d2e7ed439cce8a3/lightgbm-4.6.0.tar.gz", hash = "sha256:cb1c59720eb569389c0ba74d14f52351b573af489f230032a1c9f314f8bab7fe", size = 1703705, upload-time = "2025-02-15T04:03:03.111Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f2/75/cffc9962cca296bc5536896b7e65b4a7cdeb8db208e71b9c0133c08f8f7e/lightgbm-4.6.0-py3-none-macosx_10_15_x86_64.whl", hash = "sha256:b7a393de8a334d5c8e490df91270f0763f83f959574d504c7ccb9eee4aef70ed", size = 2010151, upload-time = "2025-02-15T04:02:50.961Z" },
+    { url = "https://files.pythonhosted.org/packages/21/1b/550ee378512b78847930f5d74228ca1fdba2a7fbdeaac9aeccc085b0e257/lightgbm-4.6.0-py3-none-macosx_12_0_arm64.whl", hash = "sha256:2dafd98d4e02b844ceb0b61450a660681076b1ea6c7adb8c566dfd66832aafad", size = 1592172, upload-time = "2025-02-15T04:02:53.937Z" },
+    { url = "https://files.pythonhosted.org/packages/64/41/4fbde2c3d29e25ee7c41d87df2f2e5eda65b431ee154d4d462c31041846c/lightgbm-4.6.0-py3-none-manylinux2014_aarch64.whl", hash = "sha256:4d68712bbd2b57a0b14390cbf9376c1d5ed773fa2e71e099cac588703b590336", size = 3454567, upload-time = "2025-02-15T04:02:56.443Z" },
+    { url = "https://files.pythonhosted.org/packages/42/86/dabda8fbcb1b00bcfb0003c3776e8ade1aa7b413dff0a2c08f457dace22f/lightgbm-4.6.0-py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:cb19b5afea55b5b61cbb2131095f50538bd608a00655f23ad5d25ae3e3bf1c8d", size = 3569831, upload-time = "2025-02-15T04:02:58.925Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/23/f8b28ca248bb629b9e08f877dd2965d1994e1674a03d67cd10c5246da248/lightgbm-4.6.0-py3-none-win_amd64.whl", hash = "sha256:37089ee95664b6550a7189d887dbf098e3eadab03537e411f52c63c121e3ba4b", size = 1451509, upload-time = "2025-02-15T04:03:01.515Z" },
+]
+
+[[package]]
 name = "llvmlite"
 version = "0.47.0"
 source = { registry = "https://pypi.org/simple" }
@@ -662,9 +709,11 @@ name = "mamut"
 version = "0.2.1"
 source = { editable = "." }
 dependencies = [
+    { name = "catboost" },
     { name = "imbalanced-learn" },
     { name = "jinja2" },
     { name = "joblib" },
+    { name = "lightgbm" },
     { name = "matplotlib" },
     { name = "numpy" },
     { name = "optuna" },
@@ -717,9 +766,11 @@ test = [
 
 [package.metadata]
 requires-dist = [
+    { name = "catboost", specifier = ">=1.2.10,<2.0.0" },
     { name = "imbalanced-learn", specifier = ">=0.13.0,<0.14.0" },
     { name = "jinja2", specifier = ">=3.0.2,<4.0.0" },
     { name = "joblib", specifier = ">=1.4.2,<2.0.0" },
+    { name = "lightgbm", specifier = ">=4.6.0,<5.0.0" },
     { name = "matplotlib", specifier = ">=3.10.0,<4.0.0" },
     { name = "numpy", specifier = ">=2.0.0,<2.1.0" },
     { name = "optuna", specifier = ">=4.1.0,<5.0.0" },
@@ -863,6 +914,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/41/0d/2ddfaa8b7e1cee6c490d46cb0a39742b19e2481600a7a0e96537e9c22f43/msgpack-1.1.2-cp312-cp312-win32.whl", hash = "sha256:1fff3d825d7859ac888b0fbda39a42d59193543920eda9d9bea44d958a878029", size = 65096, upload-time = "2025-10-08T09:15:11.11Z" },
     { url = "https://files.pythonhosted.org/packages/8c/ec/d431eb7941fb55a31dd6ca3404d41fbb52d99172df2e7707754488390910/msgpack-1.1.2-cp312-cp312-win_amd64.whl", hash = "sha256:1de460f0403172cff81169a30b9a92b260cb809c4cb7e2fc79ae8d0510c78b6b", size = 72708, upload-time = "2025-10-08T09:15:12.554Z" },
     { url = "https://files.pythonhosted.org/packages/c5/31/5b1a1f70eb0e87d1678e9624908f86317787b536060641d6798e3cf70ace/msgpack-1.1.2-cp312-cp312-win_arm64.whl", hash = "sha256:be5980f3ee0e6bd44f3a9e9dea01054f175b50c3e6cdb692bc9424c0bbb8bf69", size = 64119, upload-time = "2025-10-08T09:15:13.589Z" },
+]
+
+[[package]]
+name = "narwhals"
+version = "2.21.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cf/a0/6198c56d42ef2f3c6ed0c42ba30dbcefdc86a91262d7d449010770ae085b/narwhals-2.21.2.tar.gz", hash = "sha256:5c5b2d0b47aef7c73ea412cfcbcd467f2f2d5be73e3c2ab19d78f4a97718790a", size = 632176, upload-time = "2026-05-16T08:49:08.314Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1d/77/928ea2e70641ca177a11140062cc5840d421795f2e82749d408d0cce900a/narwhals-2.21.2-py3-none-any.whl", hash = "sha256:7bb57c3700486039215455b9bf2d64261915cc0fd845cc30272d631df696b251", size = 451201, upload-time = "2026-05-16T08:49:05.536Z" },
 ]
 
 [[package]]
@@ -1160,6 +1220,19 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/9f/4a/0883b8e3802965322523f0b200ecf33d31f10991d0401162f4b23c698b42/platformdirs-4.9.6.tar.gz", hash = "sha256:3bfa75b0ad0db84096ae777218481852c0ebc6c727b3168c1b9e0118e458cf0a", size = 29400, upload-time = "2026-04-09T00:04:10.812Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/75/a6/a0a304dc33b49145b21f4808d763822111e67d1c3a32b524a1baf947b6e1/platformdirs-4.9.6-py3-none-any.whl", hash = "sha256:e61adb1d5e5cb3441b4b7710bea7e4c12250ca49439228cc1021c00dcfac0917", size = 21348, upload-time = "2026-04-09T00:04:09.463Z" },
+]
+
+[[package]]
+name = "plotly"
+version = "6.7.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "narwhals" },
+    { name = "packaging" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3a/7f/0f100df1172aadf88a929a9dbb902656b0880ba4b960fe5224867159d8f4/plotly-6.7.0.tar.gz", hash = "sha256:45eea0ff27e2a23ccd62776f77eb43aa1ca03df4192b76036e380bb479b892c6", size = 6911286, upload-time = "2026-04-09T20:36:45.738Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/90/ad/cba91b3bcf04073e4d1655a5c1710ef3f457f56f7d1b79dcc3d72f4dd912/plotly-6.7.0-py3-none-any.whl", hash = "sha256:ac8aca1c25c663a59b5b9140a549264a5badde2e057d79b8c772ae2920e32ff0", size = 9898444, upload-time = "2026-04-09T20:36:39.812Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- add model-aware candidate selection with LightGBM and CatBoost support
- add explicit benchmark protocol controls, immutable Kaggle campaign records, and fixed-parameter submission refitting
- document recorded Spaceship Titanic evidence and limitations without leaderboard-superiority claims
- expand focused selection, preprocessing, evidence, and Kaggle harness tests

## Recorded evidence
- official Kaggle public submissions: `0.79798` (LightGBM initial campaign) and `0.80617` (CatBoost post-score campaign)
- the latter is documented as post-leaderboard development evidence, not an independent final estimate
- regenerated sklearn evidence diagnostics intentionally expose baseline challenges, including `breast_cancer`

## Validation
- `uv run pytest -q` (`74 passed`)
- `uv run deptry .`
- `bash scripts/audit_dependencies.sh`
- `uv run pre-commit run --all-files`
- `uv run sphinx-build -W --keep-going -b html docs/source docs/build/html-strict-feature`
- `uv run sphinx-build -b linkcheck docs/source docs/build/linkcheck-plan-audit`
- `uv run python scripts/benchmark_evidence.py --format markdown`
- `git diff --check`

## Release note
This is intended for inclusion in `v0.3.0`; behavior-sensitive dependency upgrades are intentionally handled separately.