### PR TITLE
deps: refresh sphinx-autodoc-typehints for Sphinx 9

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -1916,14 +1916,14 @@ wheels = [
 
 [[package]]
 name = "sphinx-autodoc-typehints"
-version = "3.5.2"
+version = "3.10.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "sphinx" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/34/4f/4fd5583678bb7dc8afa69e9b309e6a99ee8d79ad3a4728f4e52fd7cb37c7/sphinx_autodoc_typehints-3.5.2.tar.gz", hash = "sha256:5fcd4a3eb7aa89424c1e2e32bedca66edc38367569c9169a80f4b3e934171fdb", size = 37839, upload-time = "2025-10-16T00:50:15.743Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/75/75/9a5695b3d3b848a43cfe91c7d7d3c5ab543eb3bc5c2a12ffaf5003a2a4f6/sphinx_autodoc_typehints-3.10.2.tar.gz", hash = "sha256:34db651eb14343ba16bd9c03e0f5093971f9bbd3cc6b0a1470adecd578940b9c", size = 74241, upload-time = "2026-04-15T22:09:48.87Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/05/f2/9657c98a66973b7c35bfd48ba65d1922860de9598fbb535cd96e3f58a908/sphinx_autodoc_typehints-3.5.2-py3-none-any.whl", hash = "sha256:0accd043619f53c86705958e323b419e41667917045ac9215d7be1b493648d8c", size = 21184, upload-time = "2025-10-16T00:50:13.973Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/0f/f1c2e2592f995d301bc06901fbb2e947cbe4889397a418309710ccc3a1db/sphinx_autodoc_typehints-3.10.2-py3-none-any.whl", hash = "sha256:2d1bcac8f62b8d0d210f6ca44b8e016e314d07cc8c30d0512cf6986a0b042b26", size = 39231, upload-time = "2026-04-15T22:09:47.413Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- update the documentation-only lock entry for `sphinx-autodoc-typehints` from `3.5.2` to `3.10.2` within the existing `>=3.0.0,<4.0.0` declaration
- remove `RemovedInSphinx10Warning` messages produced by the accepted Sphinx 9 documentation build

No runtime dependency or published `v0.3.0` artifact changes.

## Validation

- `uv sync --locked --all-groups`
- `uv run deptry .`
- `uv run pre-commit run --all-files`
- `uv run sphinx-build -W --keep-going -b html docs/source docs/build/html-strict-autodoc`
- confirmed no `RemovedInSphinx`, `deprecated`, or `WARNING` output in the fresh HTML build
- `uv run sphinx-build -b linkcheck docs/source docs/build/linkcheck-autodoc`